### PR TITLE
Remove commit signing requirement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,12 +82,6 @@ Date:   Mon Aug 1 11:27:13 2020 -0400
 
 [//]: # (TODO: PR title and description)
 
-## Sign your commits
-
-To ensure the authenticity and integrity of code contributions, **we require that all commits are signed**. Signing commits proves that your commits were truly created by you, as the holder of a private key.
-
-Configuring git to sign your commits is a straightforward process. To get set up, see [GitHub's documentation on signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
-
 ## Test your changes
 
 Ensure that your changes have passed the test suite. For more information on working with this project's tests, see https://github.com/anchore/sbom-action/blob/main/DEVELOPING.md#tests.


### PR DESCRIPTION
The core team discussed that the commit signing requirement should be dropped, since it's adding significant friction to the community PR process without a tangible security benefit. We'll revisit this in the future as the tooling around commit signing and verification improves.

This PR removes the commit signing section of CONTRIBUTING.md. I've also updated the setting itself.
