### PR TITLE
Only run Syft auto-update in main repo

### DIFF
--- a/.github/workflows/update-syft-release.yml
+++ b/.github/workflows/update-syft-release.yml
@@ -10,12 +10,13 @@ on:
 jobs:
   upgrade-syft:
     runs-on: ubuntu-latest
+    if: github.repository == 'anchore/sbom-action'
     steps:
       - uses: actions/checkout@v3
       - run: |
           LATEST_VERSION=$(curl "https://api.github.com/repos/anchore/syft/releases/latest" 2>/dev/null | jq -r '.tag_name')
           echo "export const VERSION = \"$LATEST_VERSION\";" > src/SyftVersion.ts
-          # since husky hooks are not installed, manually run this:
+          # install husky hooks and dependencies:
           npm install
           # export the version for use with create-pull-request:
           echo "::set-output name=LATEST_VERSION::$LATEST_VERSION"


### PR DESCRIPTION
The Syft auto-update will fail for any forks, we just want it running in the main repo.