### PR TITLE
Don't use JSON.stringify for logging purposes

### DIFF
--- a/dist/attachReleaseAssets/index.js
+++ b/dist/attachReleaseAssets/index.js
@@ -18799,8 +18799,7 @@ function dashWrap(str) {
 }
 exports.dashWrap = dashWrap;
 /**
- * Logs all objects passed in debug outputting strings directly and
- * calling JSON.stringify on other elements in a group with the given label
+ * Attempts to intelligently log all objects passed in when debug is enabled
  */
 function debugLog(label, ...args) {
     if (core.isDebug()) {
@@ -18811,10 +18810,10 @@ function debugLog(label, ...args) {
                 }
                 else if (arg instanceof Error) {
                     core.debug(arg.message);
-                    core.debug(JSON.stringify(arg.stack));
+                    console.log(arg.stack);
                 }
                 else {
-                    core.debug(JSON.stringify(arg));
+                    console.log(arg);
                 }
             }
         }));
@@ -19028,14 +19027,16 @@ class GithubClient {
                     data: JSON.stringify(snapshot),
                 });
                 if (response.status >= 400) {
-                    core.warning(`Dependency snapshot upload failed: ${JSON.stringify(response)}`);
+                    core.warning(`Dependency snapshot upload failed:`);
+                    console.log(response);
                 }
                 else {
                     debugLog(`Dependency snapshot upload successful:`, response);
                 }
             }
             catch (e) {
-                core.warning(`Error uploading depdendency snapshot: ${JSON.stringify(e)}`);
+                core.warning(`Error uploading depdendency snapshot:`);
+                console.log(e);
             }
         });
     }
@@ -19474,7 +19475,7 @@ function runSyftAction() {
             }
         }
         else {
-            throw new Error(`No Syft output: ${JSON.stringify(output)}`);
+            throw new Error(`No Syft output`);
         }
     });
 }
@@ -19619,7 +19620,13 @@ function runAndFailBuildOnException(fn) {
                 core.setFailed(e.message);
             }
             else if (e instanceof Object) {
-                core.setFailed(JSON.stringify(e));
+                try {
+                    core.setFailed(JSON.stringify(e));
+                }
+                catch (e) {
+                    core.setFailed("Action failed");
+                    console.error(e);
+                }
             }
             else {
                 core.setFailed(`An unknown error occurred: ${e}`);

--- a/dist/downloadSyft/index.js
+++ b/dist/downloadSyft/index.js
@@ -18843,8 +18843,7 @@ function dashWrap(str) {
 }
 exports.dashWrap = dashWrap;
 /**
- * Logs all objects passed in debug outputting strings directly and
- * calling JSON.stringify on other elements in a group with the given label
+ * Attempts to intelligently log all objects passed in when debug is enabled
  */
 function debugLog(label, ...args) {
     if (core.isDebug()) {
@@ -18855,10 +18854,10 @@ function debugLog(label, ...args) {
                 }
                 else if (arg instanceof Error) {
                     core.debug(arg.message);
-                    core.debug(JSON.stringify(arg.stack));
+                    console.log(arg.stack);
                 }
                 else {
-                    core.debug(JSON.stringify(arg));
+                    console.log(arg);
                 }
             }
         }));
@@ -19072,14 +19071,16 @@ class GithubClient {
                     data: JSON.stringify(snapshot),
                 });
                 if (response.status >= 400) {
-                    core.warning(`Dependency snapshot upload failed: ${JSON.stringify(response)}`);
+                    core.warning(`Dependency snapshot upload failed:`);
+                    console.log(response);
                 }
                 else {
                     debugLog(`Dependency snapshot upload successful:`, response);
                 }
             }
             catch (e) {
-                core.warning(`Error uploading depdendency snapshot: ${JSON.stringify(e)}`);
+                core.warning(`Error uploading depdendency snapshot:`);
+                console.log(e);
             }
         });
     }
@@ -19518,7 +19519,7 @@ function runSyftAction() {
             }
         }
         else {
-            throw new Error(`No Syft output: ${JSON.stringify(output)}`);
+            throw new Error(`No Syft output`);
         }
     });
 }
@@ -19663,7 +19664,13 @@ function runAndFailBuildOnException(fn) {
                 core.setFailed(e.message);
             }
             else if (e instanceof Object) {
-                core.setFailed(JSON.stringify(e));
+                try {
+                    core.setFailed(JSON.stringify(e));
+                }
+                catch (e) {
+                    core.setFailed("Action failed");
+                    console.error(e);
+                }
             }
             else {
                 core.setFailed(`An unknown error occurred: ${e}`);

--- a/dist/runSyftAction/index.js
+++ b/dist/runSyftAction/index.js
@@ -18799,8 +18799,7 @@ function dashWrap(str) {
 }
 exports.dashWrap = dashWrap;
 /**
- * Logs all objects passed in debug outputting strings directly and
- * calling JSON.stringify on other elements in a group with the given label
+ * Attempts to intelligently log all objects passed in when debug is enabled
  */
 function debugLog(label, ...args) {
     if (core.isDebug()) {
@@ -18811,10 +18810,10 @@ function debugLog(label, ...args) {
                 }
                 else if (arg instanceof Error) {
                     core.debug(arg.message);
-                    core.debug(JSON.stringify(arg.stack));
+                    console.log(arg.stack);
                 }
                 else {
-                    core.debug(JSON.stringify(arg));
+                    console.log(arg);
                 }
             }
         }));
@@ -19028,14 +19027,16 @@ class GithubClient {
                     data: JSON.stringify(snapshot),
                 });
                 if (response.status >= 400) {
-                    core.warning(`Dependency snapshot upload failed: ${JSON.stringify(response)}`);
+                    core.warning(`Dependency snapshot upload failed:`);
+                    console.log(response);
                 }
                 else {
                     debugLog(`Dependency snapshot upload successful:`, response);
                 }
             }
             catch (e) {
-                core.warning(`Error uploading depdendency snapshot: ${JSON.stringify(e)}`);
+                core.warning(`Error uploading depdendency snapshot:`);
+                console.log(e);
             }
         });
     }
@@ -19474,7 +19475,7 @@ function runSyftAction() {
             }
         }
         else {
-            throw new Error(`No Syft output: ${JSON.stringify(output)}`);
+            throw new Error(`No Syft output`);
         }
     });
 }
@@ -19619,7 +19620,13 @@ function runAndFailBuildOnException(fn) {
                 core.setFailed(e.message);
             }
             else if (e instanceof Object) {
-                core.setFailed(JSON.stringify(e));
+                try {
+                    core.setFailed(JSON.stringify(e));
+                }
+                catch (e) {
+                    core.setFailed("Action failed");
+                    console.error(e);
+                }
             }
             else {
                 core.setFailed(`An unknown error occurred: ${e}`);

--- a/src/github/GithubClient.ts
+++ b/src/github/GithubClient.ts
@@ -96,8 +96,7 @@ export function dashWrap(str: string): string {
 }
 
 /**
- * Logs all objects passed in debug outputting strings directly and
- * calling JSON.stringify on other elements in a group with the given label
+ * Attempts to intelligently log all objects passed in when debug is enabled
  */
 export function debugLog(label: string, ...args: unknown[]): void {
   if (core.isDebug()) {
@@ -107,9 +106,9 @@ export function debugLog(label: string, ...args: unknown[]): void {
           core.debug(arg);
         } else if (arg instanceof Error) {
           core.debug(arg.message);
-          core.debug(JSON.stringify(arg.stack));
+          console.log(arg.stack);
         } else {
-          core.debug(JSON.stringify(arg));
+          console.log(arg);
         }
       }
     });
@@ -432,16 +431,14 @@ export class GithubClient {
       );
 
       if (response.status >= 400) {
-        core.warning(
-          `Dependency snapshot upload failed: ${JSON.stringify(response)}`
-        );
+        core.warning(`Dependency snapshot upload failed:`);
+        console.log(response);
       } else {
         debugLog(`Dependency snapshot upload successful:`, response);
       }
     } catch (e) {
-      core.warning(
-        `Error uploading depdendency snapshot: ${JSON.stringify(e)}`
-      );
+      core.warning(`Error uploading depdendency snapshot:`);
+      console.log(e);
     }
   }
 }

--- a/src/github/SyftGithubAction.ts
+++ b/src/github/SyftGithubAction.ts
@@ -348,7 +348,7 @@ export async function runSyftAction(): Promise<void> {
       core.exportVariable(PRIOR_ARTIFACT_ENV_VAR, getArtifactName());
     }
   } else {
-    throw new Error(`No Syft output: ${JSON.stringify(output)}`);
+    throw new Error(`No Syft output`);
   }
 }
 
@@ -517,7 +517,12 @@ export async function runAndFailBuildOnException<T>(
     if (e instanceof Error) {
       core.setFailed(e.message);
     } else if (e instanceof Object) {
-      core.setFailed(JSON.stringify(e));
+      try {
+        core.setFailed(JSON.stringify(e));
+      } catch (e) {
+        core.setFailed("Action failed");
+        console.error(e);
+      }
     } else {
       core.setFailed(`An unknown error occurred: ${e}`);
     }

--- a/tests/GithubClient.test.ts
+++ b/tests/GithubClient.test.ts
@@ -214,10 +214,10 @@ describe("Github Client", () => {
       }
     });
 
-    debugLog("the_label", { the: "obj" });
+    debugLog("the_label", "string");
 
     expect(data.debug.log.length).toBe(1);
-    expect(data.debug.log[0]).toBe("{\"the\":\"obj\"}");
+    expect(data.debug.log[0]).toBe("string");
   });
 
   it("finds a draft release", async () => {


### PR DESCRIPTION
There was an error reported during a dependency snapshot upload:
```
Error: Converting circular structure to JSON
149
    --> starting at object with constructor 'TLSSocket'
150
    |     property '_httpMessage' -> object with constructor 'ClientRequest'
151
    --- property 'socket' closes the circle
```
I have not been able to reproduce this, but I suspect there was a legitimate error during upload which is getting masked by a circular reference stringifying error, this PR replaces all `JSON.stringify` calls used for logging with `console.log` calls.