### PR TITLE
Update secret parameter names

### DIFF
--- a/.github/workflows/update-syft-release.yml
+++ b/.github/workflows/update-syft-release.yml
@@ -23,8 +23,8 @@ jobs:
       - uses: tibdex/github-app-token@v1
         id: generate-token
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          app_id: ${{ secrets.TOKEN_APP_ID }}
+          private_key: ${{ secrets.TOKEN_APP_PRIVATE_KEY }}
       - uses: peter-evans/create-pull-request@v4
         with:
           signoff: true


### PR DESCRIPTION
As the title says: secrets have been moved to org-level for the auto-update script; this should use the new keys.