### PR TITLE
File input not being passed properly to Syft invocation

### DIFF
--- a/dist/attachReleaseAssets/index.js
+++ b/dist/attachReleaseAssets/index.js
@@ -24208,6 +24208,7 @@ function runSyftAction() {
         const output = yield executeSyft({
             input: {
                 path: core.getInput("path"),
+                file: core.getInput("file"),
                 image: core.getInput("image"),
             },
             format: getSbomFormat(),

--- a/dist/downloadSyft/index.js
+++ b/dist/downloadSyft/index.js
@@ -24256,6 +24256,7 @@ function runSyftAction() {
         const output = yield executeSyft({
             input: {
                 path: core.getInput("path"),
+                file: core.getInput("file"),
                 image: core.getInput("image"),
             },
             format: getSbomFormat(),

--- a/dist/runSyftAction/index.js
+++ b/dist/runSyftAction/index.js
@@ -24208,6 +24208,7 @@ function runSyftAction() {
         const output = yield executeSyft({
             input: {
                 path: core.getInput("path"),
+                file: core.getInput("file"),
                 image: core.getInput("image"),
             },
             format: getSbomFormat(),

--- a/src/github/SyftGithubAction.ts
+++ b/src/github/SyftGithubAction.ts
@@ -339,6 +339,7 @@ export async function runSyftAction(): Promise<void> {
   const output = await executeSyft({
     input: {
       path: core.getInput("path"),
+      file: core.getInput("file"),
       image: core.getInput("image"),
     },
     format: getSbomFormat(),

--- a/tests/SyftGithubAction.test.ts
+++ b/tests/SyftGithubAction.test.ts
@@ -53,6 +53,54 @@ describe("Action", () => {
     expect(assets.length).toBe(0);
   });
 
+  it("runs with image input", async () => {
+    setData({
+      inputs: {
+        image: "some-image:latest",
+      },
+    });
+
+    await action.runSyftAction();
+
+    const { args } = data.execArgs;
+
+    expect(args).toBeDefined()
+    expect(args.length > 2).toBeTruthy();
+    expect(args[2]).toBe("some-image:latest")
+  });
+
+  it("runs with path input", async () => {
+    setData({
+      inputs: {
+        path: "some-path",
+      },
+    });
+
+    await action.runSyftAction();
+
+    const { args } = data.execArgs;
+
+    expect(args).toBeDefined()
+    expect(args.length > 2).toBeTruthy();
+    expect(args[2]).toBe("dir:some-path")
+  });
+
+  it("runs with file input", async () => {
+    setData({
+      inputs: {
+        file: "some-file.jar",
+      },
+    });
+
+    await action.runSyftAction();
+
+    const { args } = data.execArgs;
+
+    expect(args).toBeDefined()
+    expect(args.length > 2).toBeTruthy();
+    expect(args[2]).toBe("file:some-file.jar")
+  });
+
   it("runs with release uploads inputs", async () => {
     const outputFile = `${fs.mkdtempSync(
       path.join(os.tmpdir(), "sbom-action-")


### PR DESCRIPTION
This PR corrects an issue where the `file` input was not functioning properly and adds tests to validate each input type of `file`, `path`, and `image`.

Fixes #383 