### PR TITLE
[FEATURE] Added support of workflow artifact's retention policy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: Vampire/setup-wsl@v1
+      - uses: Vampire/setup-wsl@v2
         if: ${{ matrix.os == 'windows-latest' }}
         with:
           distribution: Alpine
@@ -117,3 +117,13 @@ jobs:
       - uses: ./publish-sbom # anchore/sbom-action/publish-sbom
         with:
           sbom-artifact-match: "^dont-match-anything$"
+
+      - uses: ./ # anchore/sbom-action with artifact retention
+        name: "One day artifact retention test"
+        id: one-day
+        with:
+          image: alpine:latest
+          upload-artifact-retention-days: 1
+          artifact-name: one-day.sbom.spdx
+          output-file: one-day-sbom.spdx
+          format: spdx

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,7 +123,7 @@ jobs:
         id: one-day
         with:
           image: alpine:latest
-          upload-artifact-retention-days: 1
+          upload-artifact-retention: 1
           artifact-name: one-day.sbom.spdx
           output-file: one-day-sbom.spdx
           format: spdx

--- a/README.md
+++ b/README.md
@@ -123,22 +123,22 @@ use the `artifact-name` parameter:
 The main [SBOM action](action.yml), responsible for generating SBOMs
 and uploading them as workflow artifacts and release assets.
 
-| Parameter                        | Description                                                                                                                                             | Default                          |
-| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
-| `path`                           | A path on the filesystem to scan. This is mutually exclusive to `file` and `image`.                                                                     | \<current directory>             |
-| `file`                           | A file on the filesystem to scan. This is mutually exclusive to `path` and `image`.                                                                     |                                  |
-| `image`                          | A container image to scan. This is mutually exclusive to `path` and `file`. See [Scan a container image](#scan-a-container-image) for more information. |                                  |
-| `registry-username`              | The registry username to use when authenticating to an external registry                                                                                |                                  |
-| `registry-password`              | The registry password to use when authenticating to an external registry                                                                                |                                  |
-| `artifact-name`                  | The name to use for the generated SBOM artifact. See: [Naming the SBOM output](#naming-the-sbom-output)                                                 | `sbom-<job>-<step-id>.spdx.json` |
-| `output-file`                    | The location to output a resulting SBOM                                                                                                                 |                                  |
-| `format`                         | The SBOM format to export. One of: `spdx`, `spdx-json`, `cyclonedx`, `cyclonedx-json`                                                                   | `spdx-json`                      |
-| `dependency-snapshot`            | Whether to upload the SBOM to the GitHub Dependency submission API                                                                                      | `false`                          |
-| `upload-artifact`                | Upload artifact to workflow                                                                                                                             | `true`                           |
-| `upload-artifact-retention-days` | Retention policy for uploaded artifact to workflow.                                                                                                     |                                  |
-| `upload-release-assets`          | Upload release assets                                                                                                                                   | `true`                           |
-| `syft-version`                   | The version of Syft to use                                                                                                                              |                                  |
-| `github-token`                   | Authorized secret GitHub Personal Access Token.                                                                                                         | `github.token`                   |
+| Parameter                   | Description                                                                                                                                             | Default                          |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
+| `path`                      | A path on the filesystem to scan. This is mutually exclusive to `file` and `image`.                                                                     | \<current directory>             |
+| `file`                      | A file on the filesystem to scan. This is mutually exclusive to `path` and `image`.                                                                     |                                  |
+| `image`                     | A container image to scan. This is mutually exclusive to `path` and `file`. See [Scan a container image](#scan-a-container-image) for more information. |                                  |
+| `registry-username`         | The registry username to use when authenticating to an external registry                                                                                |                                  |
+| `registry-password`         | The registry password to use when authenticating to an external registry                                                                                |                                  |
+| `artifact-name`             | The name to use for the generated SBOM artifact. See: [Naming the SBOM output](#naming-the-sbom-output)                                                 | `sbom-<job>-<step-id>.spdx.json` |
+| `output-file`               | The location to output a resulting SBOM                                                                                                                 |                                  |
+| `format`                    | The SBOM format to export. One of: `spdx`, `spdx-json`, `cyclonedx`, `cyclonedx-json`                                                                   | `spdx-json`                      |
+| `dependency-snapshot`       | Whether to upload the SBOM to the GitHub Dependency submission API                                                                                      | `false`                          |
+| `upload-artifact`           | Upload artifact to workflow                                                                                                                             | `true`                           |
+| `upload-artifact-retention` | Retention policy in days for uploaded artifact to workflow.                                                                                             |                                  |
+| `upload-release-assets`     | Upload release assets                                                                                                                                   | `true`                           |
+| `syft-version`              | The version of Syft to use                                                                                                                              |                                  |
+| `github-token`              | Authorized secret GitHub Personal Access Token.                                                                                                         | `github.token`                   |
 
 ### anchore/sbom-action/publish-sbom
 

--- a/README.md
+++ b/README.md
@@ -123,17 +123,22 @@ use the `artifact-name` parameter:
 The main [SBOM action](action.yml), responsible for generating SBOMs
 and uploading them as workflow artifacts and release assets.
 
-| Parameter             | Description                                                                                                                                             | Default                          |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
-| `path`                | A path on the filesystem to scan. This is mutually exclusive to `file` and `image`.                                                                     | \<current directory>             |
-| `file`                | A file on the filesystem to scan. This is mutually exclusive to `path` and `image`.                                                                     |                                  |
-| `image`               | A container image to scan. This is mutually exclusive to `path` and `file`. See [Scan a container image](#scan-a-container-image) for more information. |                                  |
-| `registry-username`   | The registry username to use when authenticating to an external registry                                                                                |                                  |
-| `registry-password`   | The registry password to use when authenticating to an external registry                                                                                |                                  |
-| `artifact-name`       | The name to use for the generated SBOM artifact. See: [Naming the SBOM output](#naming-the-sbom-output)                                                 | `sbom-<job>-<step-id>.spdx.json` |
-| `output-file`         | The location to output a resulting SBOM                                                                                                                 |                                  |
-| `format`              | The SBOM format to export. One of: `spdx`, `spdx-json`, `cyclonedx`, `cyclonedx-json`                                                                   | `spdx-json`                      |
-| `dependency-snapshot` | Whether to upload the SBOM to the GitHub Dependency submission API                                                                                      | `false`                          |
+| Parameter                        | Description                                                                                                                                             | Default                          |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
+| `path`                           | A path on the filesystem to scan. This is mutually exclusive to `file` and `image`.                                                                     | \<current directory>             |
+| `file`                           | A file on the filesystem to scan. This is mutually exclusive to `path` and `image`.                                                                     |                                  |
+| `image`                          | A container image to scan. This is mutually exclusive to `path` and `file`. See [Scan a container image](#scan-a-container-image) for more information. |                                  |
+| `registry-username`              | The registry username to use when authenticating to an external registry                                                                                |                                  |
+| `registry-password`              | The registry password to use when authenticating to an external registry                                                                                |                                  |
+| `artifact-name`                  | The name to use for the generated SBOM artifact. See: [Naming the SBOM output](#naming-the-sbom-output)                                                 | `sbom-<job>-<step-id>.spdx.json` |
+| `output-file`                    | The location to output a resulting SBOM                                                                                                                 |                                  |
+| `format`                         | The SBOM format to export. One of: `spdx`, `spdx-json`, `cyclonedx`, `cyclonedx-json`                                                                   | `spdx-json`                      |
+| `dependency-snapshot`            | Whether to upload the SBOM to the GitHub Dependency submission API                                                                                      | `false`                          |
+| `upload-artifact`                | Upload artifact to workflow                                                                                                                             | `true`                           |
+| `upload-artifact-retention-days` | Retention policy for uploaded artifact to workflow.                                                                                                     |                                  |
+| `upload-release-assets`          | Upload release assets                                                                                                                                   | `true`                           |
+| `syft-version`                   | The version of Syft to use                                                                                                                              |                                  |
+| `github-token`                   | Authorized secret GitHub Personal Access Token.                                                                                                         | `github.token`                   |
 
 ### anchore/sbom-action/publish-sbom
 
@@ -167,7 +172,7 @@ required to set up a WSL distribution prior to invoking the `sbom-action`, for
 example, you can add the small Alpine image:
 
 ```yaml
-- uses: Vampire/setup-wsl@v1
+- uses: Vampire/setup-wsl@v2
   with:
     distribution: Alpine
 ```

--- a/action.yml
+++ b/action.yml
@@ -58,7 +58,7 @@ inputs:
     description: "Upload artifact to workflow"
     default: "true"
 
-  upload-artifact-retention-days:
+  upload-artifact-retention:
     required: false
     description: >
       Retention policy for uploaded artifact to workflow.
@@ -66,6 +66,7 @@ inputs:
       Minimum 1 day.
       Maximum 90 days unless changed from the repository settings page.
       An input of 0 assumes default retention value.
+    default: 0
 
   upload-release-assets:
     required: false

--- a/action.yml
+++ b/action.yml
@@ -58,6 +58,15 @@ inputs:
     description: "Upload artifact to workflow"
     default: "true"
 
+  upload-artifact-retention-days:
+    required: false
+    description: >
+      Retention policy for uploaded artifact to workflow.
+
+      Minimum 1 day.
+      Maximum 90 days unless changed from the repository settings page.
+      An input of 0 assumes default retention value.
+
   upload-release-assets:
     required: false
     description: "Upload release assets"

--- a/dist/attachReleaseAssets/index.js
+++ b/dist/attachReleaseAssets/index.js
@@ -6552,6 +6552,10 @@ function checkBypass(reqUrl) {
     if (!reqUrl.hostname) {
         return false;
     }
+    const reqHost = reqUrl.hostname;
+    if (isLoopbackAddress(reqHost)) {
+        return true;
+    }
     const noProxy = process.env['no_proxy'] || process.env['NO_PROXY'] || '';
     if (!noProxy) {
         return false;
@@ -6577,13 +6581,24 @@ function checkBypass(reqUrl) {
         .split(',')
         .map(x => x.trim().toUpperCase())
         .filter(x => x)) {
-        if (upperReqHosts.some(x => x === upperNoProxyItem)) {
+        if (upperNoProxyItem === '*' ||
+            upperReqHosts.some(x => x === upperNoProxyItem ||
+                x.endsWith(`.${upperNoProxyItem}`) ||
+                (upperNoProxyItem.startsWith('.') &&
+                    x.endsWith(`${upperNoProxyItem}`)))) {
             return true;
         }
     }
     return false;
 }
 exports.checkBypass = checkBypass;
+function isLoopbackAddress(host) {
+    const hostLower = host.toLowerCase();
+    return (hostLower === 'localhost' ||
+        hostLower.startsWith('127.') ||
+        hostLower.startsWith('[::1]') ||
+        hostLower.startsWith('[0:0:0:0:0:0:0:1]'));
+}
 //# sourceMappingURL=proxy.js.map
 
 /***/ }),

--- a/dist/attachReleaseAssets/index.js
+++ b/dist/attachReleaseAssets/index.js
@@ -23604,17 +23604,20 @@ class GithubClient {
      * Uploads a workflow artifact for the current workflow run
      * @param name name of the artifact
      * @param file file to upload
+     * @param retentionDays retention days of a artifact
      */
-    uploadWorkflowArtifact({ name, file, }) {
+    uploadWorkflowArtifact({ name, file, retention, }) {
         return __awaiter(this, void 0, void 0, function* () {
             const rootDirectory = path_1.default.dirname(file);
             const client = (0, artifact_1.create)();
-            debugLog("uploadArtifact:", name, file, rootDirectory, core.isDebug() && fs_1.default.readdirSync(rootDirectory));
-            const info = yield suppressOutput(() => __awaiter(this, void 0, void 0, function* () {
-                return client.uploadArtifact(name, [file], rootDirectory, {
-                    continueOnError: false,
-                });
-            }));
+            debugLog("uploadArtifact:", name, file, retention, rootDirectory, core.isDebug() && fs_1.default.readdirSync(rootDirectory));
+            const options = {
+                continueOnError: false,
+            };
+            if (retention) {
+                options.retentionDays = retention;
+            }
+            const info = yield suppressOutput(() => __awaiter(this, void 0, void 0, function* () { return client.uploadArtifact(name, [file], rootDirectory, options); }));
             debugLog("uploadArtifact response:", info);
         });
     }
@@ -24146,6 +24149,7 @@ function uploadSbomArtifact(contents) {
         const fileName = getArtifactName();
         const filePath = `${tempDir}/${fileName}`;
         fs.writeFileSync(filePath, contents);
+        const retentionDays = parseInt(core.getInput("upload-artifact-retention-days"));
         const outputFile = core.getInput("output-file");
         if (outputFile) {
             fs.copyFileSync(filePath, outputFile);
@@ -24155,6 +24159,7 @@ function uploadSbomArtifact(contents) {
         yield client.uploadWorkflowArtifact({
             file: filePath,
             name: fileName,
+            retention: retentionDays,
         });
     });
 }

--- a/dist/attachReleaseAssets/index.js
+++ b/dist/attachReleaseAssets/index.js
@@ -23604,7 +23604,7 @@ class GithubClient {
      * Uploads a workflow artifact for the current workflow run
      * @param name name of the artifact
      * @param file file to upload
-     * @param retentionDays retention days of a artifact
+     * @param retention retention days of a artifact
      */
     uploadWorkflowArtifact({ name, file, retention, }) {
         return __awaiter(this, void 0, void 0, function* () {
@@ -24149,7 +24149,7 @@ function uploadSbomArtifact(contents) {
         const fileName = getArtifactName();
         const filePath = `${tempDir}/${fileName}`;
         fs.writeFileSync(filePath, contents);
-        const retentionDays = parseInt(core.getInput("upload-artifact-retention-days"));
+        const retentionDays = parseInt(core.getInput("upload-artifact-retention"));
         const outputFile = core.getInput("output-file");
         if (outputFile) {
             fs.copyFileSync(filePath, outputFile);

--- a/dist/downloadSyft/index.js
+++ b/dist/downloadSyft/index.js
@@ -6552,6 +6552,10 @@ function checkBypass(reqUrl) {
     if (!reqUrl.hostname) {
         return false;
     }
+    const reqHost = reqUrl.hostname;
+    if (isLoopbackAddress(reqHost)) {
+        return true;
+    }
     const noProxy = process.env['no_proxy'] || process.env['NO_PROXY'] || '';
     if (!noProxy) {
         return false;
@@ -6577,13 +6581,24 @@ function checkBypass(reqUrl) {
         .split(',')
         .map(x => x.trim().toUpperCase())
         .filter(x => x)) {
-        if (upperReqHosts.some(x => x === upperNoProxyItem)) {
+        if (upperNoProxyItem === '*' ||
+            upperReqHosts.some(x => x === upperNoProxyItem ||
+                x.endsWith(`.${upperNoProxyItem}`) ||
+                (upperNoProxyItem.startsWith('.') &&
+                    x.endsWith(`${upperNoProxyItem}`)))) {
             return true;
         }
     }
     return false;
 }
 exports.checkBypass = checkBypass;
+function isLoopbackAddress(host) {
+    const hostLower = host.toLowerCase();
+    return (hostLower === 'localhost' ||
+        hostLower.startsWith('127.') ||
+        hostLower.startsWith('[::1]') ||
+        hostLower.startsWith('[0:0:0:0:0:0:0:1]'));
+}
 //# sourceMappingURL=proxy.js.map
 
 /***/ }),

--- a/dist/downloadSyft/index.js
+++ b/dist/downloadSyft/index.js
@@ -23652,7 +23652,7 @@ class GithubClient {
      * Uploads a workflow artifact for the current workflow run
      * @param name name of the artifact
      * @param file file to upload
-     * @param retentionDays retention days of a artifact
+     * @param retention retention days of a artifact
      */
     uploadWorkflowArtifact({ name, file, retention, }) {
         return __awaiter(this, void 0, void 0, function* () {
@@ -24197,7 +24197,7 @@ function uploadSbomArtifact(contents) {
         const fileName = getArtifactName();
         const filePath = `${tempDir}/${fileName}`;
         fs.writeFileSync(filePath, contents);
-        const retentionDays = parseInt(core.getInput("upload-artifact-retention-days"));
+        const retentionDays = parseInt(core.getInput("upload-artifact-retention"));
         const outputFile = core.getInput("output-file");
         if (outputFile) {
             fs.copyFileSync(filePath, outputFile);

--- a/dist/runSyftAction/index.js
+++ b/dist/runSyftAction/index.js
@@ -6552,6 +6552,10 @@ function checkBypass(reqUrl) {
     if (!reqUrl.hostname) {
         return false;
     }
+    const reqHost = reqUrl.hostname;
+    if (isLoopbackAddress(reqHost)) {
+        return true;
+    }
     const noProxy = process.env['no_proxy'] || process.env['NO_PROXY'] || '';
     if (!noProxy) {
         return false;
@@ -6577,13 +6581,24 @@ function checkBypass(reqUrl) {
         .split(',')
         .map(x => x.trim().toUpperCase())
         .filter(x => x)) {
-        if (upperReqHosts.some(x => x === upperNoProxyItem)) {
+        if (upperNoProxyItem === '*' ||
+            upperReqHosts.some(x => x === upperNoProxyItem ||
+                x.endsWith(`.${upperNoProxyItem}`) ||
+                (upperNoProxyItem.startsWith('.') &&
+                    x.endsWith(`${upperNoProxyItem}`)))) {
             return true;
         }
     }
     return false;
 }
 exports.checkBypass = checkBypass;
+function isLoopbackAddress(host) {
+    const hostLower = host.toLowerCase();
+    return (hostLower === 'localhost' ||
+        hostLower.startsWith('127.') ||
+        hostLower.startsWith('[::1]') ||
+        hostLower.startsWith('[0:0:0:0:0:0:0:1]'));
+}
 //# sourceMappingURL=proxy.js.map
 
 /***/ }),

--- a/dist/runSyftAction/index.js
+++ b/dist/runSyftAction/index.js
@@ -23604,17 +23604,20 @@ class GithubClient {
      * Uploads a workflow artifact for the current workflow run
      * @param name name of the artifact
      * @param file file to upload
+     * @param retentionDays retention days of a artifact
      */
-    uploadWorkflowArtifact({ name, file, }) {
+    uploadWorkflowArtifact({ name, file, retention, }) {
         return __awaiter(this, void 0, void 0, function* () {
             const rootDirectory = path_1.default.dirname(file);
             const client = (0, artifact_1.create)();
-            debugLog("uploadArtifact:", name, file, rootDirectory, core.isDebug() && fs_1.default.readdirSync(rootDirectory));
-            const info = yield suppressOutput(() => __awaiter(this, void 0, void 0, function* () {
-                return client.uploadArtifact(name, [file], rootDirectory, {
-                    continueOnError: false,
-                });
-            }));
+            debugLog("uploadArtifact:", name, file, retention, rootDirectory, core.isDebug() && fs_1.default.readdirSync(rootDirectory));
+            const options = {
+                continueOnError: false,
+            };
+            if (retention) {
+                options.retentionDays = retention;
+            }
+            const info = yield suppressOutput(() => __awaiter(this, void 0, void 0, function* () { return client.uploadArtifact(name, [file], rootDirectory, options); }));
             debugLog("uploadArtifact response:", info);
         });
     }
@@ -24146,6 +24149,7 @@ function uploadSbomArtifact(contents) {
         const fileName = getArtifactName();
         const filePath = `${tempDir}/${fileName}`;
         fs.writeFileSync(filePath, contents);
+        const retentionDays = parseInt(core.getInput("upload-artifact-retention-days"));
         const outputFile = core.getInput("output-file");
         if (outputFile) {
             fs.copyFileSync(filePath, outputFile);
@@ -24155,6 +24159,7 @@ function uploadSbomArtifact(contents) {
         yield client.uploadWorkflowArtifact({
             file: filePath,
             name: fileName,
+            retention: retentionDays,
         });
     });
 }

--- a/dist/runSyftAction/index.js
+++ b/dist/runSyftAction/index.js
@@ -23604,7 +23604,7 @@ class GithubClient {
      * Uploads a workflow artifact for the current workflow run
      * @param name name of the artifact
      * @param file file to upload
-     * @param retentionDays retention days of a artifact
+     * @param retention retention days of a artifact
      */
     uploadWorkflowArtifact({ name, file, retention, }) {
         return __awaiter(this, void 0, void 0, function* () {
@@ -24149,7 +24149,7 @@ function uploadSbomArtifact(contents) {
         const fileName = getArtifactName();
         const filePath = `${tempDir}/${fileName}`;
         fs.writeFileSync(filePath, contents);
-        const retentionDays = parseInt(core.getInput("upload-artifact-retention-days"));
+        const retentionDays = parseInt(core.getInput("upload-artifact-retention"));
         const outputFile = core.getInput("output-file");
         if (outputFile) {
             fs.copyFileSync(filePath, outputFile);

--- a/package-lock.json
+++ b/package-lock.json
@@ -4838,9 +4838,9 @@
       "dev": true
     },
     "node_modules/http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
     "node_modules/http-proxy-agent": {
       "version": "5.0.0",
@@ -7333,7 +7333,7 @@
       "dependencies": {
         "agentkeepalive": "^4.2.1",
         "cacache": "^16.1.0",
-        "http-cache-semantics": "^4.1.0",
+        "http-cache-semantics": "^4.1.1",
         "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
         "is-lambda": "^1.0.1",
@@ -14134,9 +14134,9 @@
       "dev": true
     },
     "http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
     "http-proxy-agent": {
       "version": "5.0.0",
@@ -15962,7 +15962,7 @@
       "requires": {
         "agentkeepalive": "^4.2.1",
         "cacache": "^16.1.0",
-        "http-cache-semantics": "^4.1.0",
+        "http-cache-semantics": "^4.1.1",
         "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
         "is-lambda": "^1.0.1",

--- a/src/github/GithubClient.ts
+++ b/src/github/GithubClient.ts
@@ -180,7 +180,7 @@ export class GithubClient {
    * Uploads a workflow artifact for the current workflow run
    * @param name name of the artifact
    * @param file file to upload
-   * @param retentionDays retention days of a artifact
+   * @param retention retention days of a artifact
    */
   async uploadWorkflowArtifact({
     name,

--- a/src/github/GithubClient.ts
+++ b/src/github/GithubClient.ts
@@ -1,4 +1,7 @@
-import { create as createArtifactClient } from "@actions/artifact";
+import {
+  create as createArtifactClient,
+  UploadOptions,
+} from "@actions/artifact";
 import { DownloadHttpClient } from "@actions/artifact/lib/internal/download-http-client";
 import * as core from "@actions/core";
 import * as github from "@actions/github";
@@ -177,13 +180,16 @@ export class GithubClient {
    * Uploads a workflow artifact for the current workflow run
    * @param name name of the artifact
    * @param file file to upload
+   * @param retentionDays retention days of a artifact
    */
   async uploadWorkflowArtifact({
     name,
     file,
+    retention,
   }: {
     name: string;
     file: string;
+    retention?: number;
   }): Promise<void> {
     const rootDirectory = path.dirname(file);
     const client = createArtifactClient();
@@ -192,14 +198,20 @@ export class GithubClient {
       "uploadArtifact:",
       name,
       file,
+      retention,
       rootDirectory,
       core.isDebug() && fs.readdirSync(rootDirectory)
     );
 
+    const options: UploadOptions = {
+      continueOnError: false,
+    };
+    if (retention) {
+      options.retentionDays = retention;
+    }
+
     const info = await suppressOutput(async () =>
-      client.uploadArtifact(name, [file], rootDirectory, {
-        continueOnError: false,
-      })
+      client.uploadArtifact(name, [file], rootDirectory, options)
     );
 
     debugLog("uploadArtifact response:", info);

--- a/src/github/SyftGithubAction.ts
+++ b/src/github/SyftGithubAction.ts
@@ -257,9 +257,7 @@ export async function uploadSbomArtifact(contents: string): Promise<void> {
   const filePath = `${tempDir}/${fileName}`;
   fs.writeFileSync(filePath, contents);
 
-  const retentionDays = parseInt(
-    core.getInput("upload-artifact-retention-days")
-  );
+  const retentionDays = parseInt(core.getInput("upload-artifact-retention"));
 
   const outputFile = core.getInput("output-file");
   if (outputFile) {

--- a/src/github/SyftGithubAction.ts
+++ b/src/github/SyftGithubAction.ts
@@ -257,6 +257,10 @@ export async function uploadSbomArtifact(contents: string): Promise<void> {
   const filePath = `${tempDir}/${fileName}`;
   fs.writeFileSync(filePath, contents);
 
+  const retentionDays = parseInt(
+    core.getInput("upload-artifact-retention-days")
+  );
+
   const outputFile = core.getInput("output-file");
   if (outputFile) {
     fs.copyFileSync(filePath, outputFile);
@@ -268,6 +272,7 @@ export async function uploadSbomArtifact(contents: string): Promise<void> {
   await client.uploadWorkflowArtifact({
     file: filePath,
     name: fileName,
+    retention: retentionDays,
   });
 }
 

--- a/tests/GithubClient.test.ts
+++ b/tests/GithubClient.test.ts
@@ -144,7 +144,8 @@ describe("Github Client", () => {
 
     await client.uploadWorkflowArtifact({
       name: "test",
-      file: "file"
+      file: "file",
+      retention: 2,
     });
 
     artifacts = await client.listWorkflowRunArtifacts({

--- a/tests/GithubClient.test.ts
+++ b/tests/GithubClient.test.ts
@@ -144,7 +144,7 @@ describe("Github Client", () => {
 
     await client.uploadWorkflowArtifact({
       name: "test",
-      file: "file",
+      file: "file"
     });
 
     artifacts = await client.listWorkflowRunArtifacts({

--- a/tests/GithubClient.test.ts
+++ b/tests/GithubClient.test.ts
@@ -145,7 +145,6 @@ describe("Github Client", () => {
     await client.uploadWorkflowArtifact({
       name: "test",
       file: "file",
-      retention: 2,
     });
 
     artifacts = await client.listWorkflowRunArtifacts({

--- a/tests/SyftGithubAction.test.ts
+++ b/tests/SyftGithubAction.test.ts
@@ -123,7 +123,7 @@ describe("Action", () => {
 
     await action.runSyftAction();
 
-    expect(fs.existsSync(inputs["output-file"])).toBeTruthy();
+    expect(fs.existsSync(inputs["output-file"].toString())).toBeTruthy();
 
     await action.attachReleaseAssets();
 
@@ -131,6 +131,38 @@ describe("Action", () => {
     expect(assets.length).toBe(1);
 
     expect(fs.existsSync(outputFile)).toBeTruthy();
+  });
+
+  it("runs with retention input as number", async () => {
+    setData({
+      inputs: {
+        image: "org/img",
+        "upload-artifact": "true",
+        "upload-artifact-retention": 3,
+      },
+    });
+
+    await action.runSyftAction();
+
+    const { args } = data.execArgs;
+
+    expect(inputs["upload-artifact-retention"]).toEqual(3)
+  });
+
+  it("runs with retention input as string", async () => {
+    setData({
+      inputs: {
+        image: "org/img",
+        "upload-artifact": "true",
+        "upload-artifact-retention": "3",
+      },
+    });
+
+    await action.runSyftAction();
+
+    const { args } = data.execArgs;
+
+    expect(inputs["upload-artifact-retention"]).toBe("3")
   });
 
   it("runs without uploading anything", async () => {

--- a/tests/SyftGithubAction.test.ts
+++ b/tests/SyftGithubAction.test.ts
@@ -123,7 +123,7 @@ describe("Action", () => {
 
     await action.runSyftAction();
 
-    expect(fs.existsSync(inputs["output-file"].toString())).toBeTruthy();
+    expect(fs.existsSync(inputs["output-file"] as string)).toBeTruthy();
 
     await action.attachReleaseAssets();
 
@@ -133,23 +133,7 @@ describe("Action", () => {
     expect(fs.existsSync(outputFile)).toBeTruthy();
   });
 
-  it("runs with retention input as number", async () => {
-    setData({
-      inputs: {
-        image: "org/img",
-        "upload-artifact": "true",
-        "upload-artifact-retention": 3,
-      },
-    });
-
-    await action.runSyftAction();
-
-    const { args } = data.execArgs;
-
-    expect(inputs["upload-artifact-retention"]).toEqual(3)
-  });
-
-  it("runs with retention input as string", async () => {
+  it("runs with retention input", async () => {
     setData({
       inputs: {
         image: "org/img",
@@ -160,9 +144,13 @@ describe("Action", () => {
 
     await action.runSyftAction();
 
-    const { args } = data.execArgs;
+    const { artifacts } = data;
 
-    expect(inputs["upload-artifact-retention"]).toBe("3")
+    expect(artifacts).toHaveLength(1);
+
+    const opts = (artifacts[0] as any).options
+
+    expect(opts.retentionDays).toEqual(3)
   });
 
   it("runs without uploading anything", async () => {

--- a/tests/mocks.ts
+++ b/tests/mocks.ts
@@ -9,7 +9,7 @@ export function getMocks() {
 
     workflowRuns: Partial<WorkflowRun>[] = [];
 
-    inputs: { [key: string]: string } = {};
+    inputs: { [key: string]: string | number } = {};
 
     outputs: { [key: string]: string } = {};
 
@@ -125,10 +125,12 @@ export function getMocks() {
         return {
           create() {
             return {
-              uploadArtifact(name: string, file: string) {
+              uploadArtifact(name: string, file: string, rootDirectory: string, options?: any) {
                 data.artifacts.push({
                   name: path.basename(name),
                   file,
+                  rootDirectory,
+                  options,
                 } as never);
               },
               downloadArtifact(name: string, tempPath: string) {


### PR DESCRIPTION
- added new input to support retention of workflow artifact
- updated Action `Vampire/setup-wsl` to `v2`
- added missed inputs in readme
- updated  dependency `http-cache-semantics` to `4.1.1` (https://github.com/advisories/GHSA-rc47-6667-2j5j)
- added unit tests for new input