### PR TITLE
chore: add github token to syft update check

### DIFF
--- a/.github/workflows/update-syft-release.yml
+++ b/.github/workflows/update-syft-release.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: |
-          LATEST_VERSION=$(curl "https://api.github.com/repos/anchore/syft/releases/latest" 2>/dev/null | jq -r '.tag_name')
+          LATEST_VERSION=$(curl -H "Accept: application/json" -H "Authorization: Bearer ${{ github.token }}" "https://api.github.com/repos/anchore/syft/releases/latest" 2>/dev/null | jq -r '.tag_name')
           echo "export const VERSION = \"$LATEST_VERSION\";" > src/SyftVersion.ts
           # install husky hooks and dependencies:
           npm install


### PR DESCRIPTION
When unauthenticated rate limits are reached, the Syft version check returns `null` and we get PRs like https://github.com/anchore/sbom-action/pull/404 . By adding a token, we get per-repository rate limits that are much higher (and we're only using this once or a few times a day).