### PR TITLE
chore: add workflow to update snapshots from PR comment

### DIFF
--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -1,0 +1,31 @@
+name: Update snapshots
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  update-snapshots:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/update-snapshots') }}
+    steps:
+      - name: Generate token
+        uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.TOKEN_APP_ID }}
+          private_key: ${{ secrets.TOKEN_APP_PRIVATE_KEY }}
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+      - name: Update snapshots
+        run: |
+          # install husky hooks and dependencies:
+          npm install
+          # update snapshots
+          npm run test:update-snapshots
+      - name: Commit snapshots
+        run: |
+          git config --global user.name 'anchore-actions'
+          git config --global user.email 'anchore-actions@users.noreply.github.com'
+          git commit -s -am "chore(test): update snapshots"
+          git push


### PR DESCRIPTION
This PR adds a workflow that triggers when `/update-snapshots` comment is made on a PR that runs the `npm run test:update-snaphshots` and pushes to the PR branch, triggering test workflows to be re-run.