### PR TITLE
chore: update deprecated set-output calls

### DIFF
--- a/.github/workflows/update-syft-release.yml
+++ b/.github/workflows/update-syft-release.yml
@@ -19,7 +19,7 @@ jobs:
           # install husky hooks and dependencies:
           npm install
           # export the version for use with create-pull-request:
-          echo "::set-output name=LATEST_VERSION::$LATEST_VERSION"
+          echo "LATEST_VERSION=$LATEST_VERSION" >> $GITHUB_OUTPUT
         id: latest-version
       - uses: tibdex/github-app-token@v1
         id: generate-token


### PR DESCRIPTION
Update deprecated `::set-output` calls