### PR TITLE
fix: ensure sbom is copied to `output-file`

### DIFF
--- a/dist/attachReleaseAssets/index.js
+++ b/dist/attachReleaseAssets/index.js
@@ -24189,10 +24189,6 @@ function uploadSbomArtifact(contents) {
         const filePath = `${tempDir}/${fileName}`;
         fs.writeFileSync(filePath, contents);
         const retentionDays = parseInt(core.getInput("upload-artifact-retention"));
-        const outputFile = core.getInput("output-file");
-        if (outputFile) {
-            fs.copyFileSync(filePath, outputFile);
-        }
         core.info((0, GithubClient_1.dashWrap)("Uploading workflow artifacts"));
         core.info(filePath);
         yield client.uploadWorkflowArtifact({
@@ -24273,6 +24269,10 @@ function runSyftAction() {
             const priorArtifact = process.env[PRIOR_ARTIFACT_ENV_VAR];
             if (priorArtifact) {
                 core.debug(`Prior artifact: ${priorArtifact}`);
+            }
+            const outputFile = core.getInput("output-file");
+            if (outputFile) {
+                fs.writeFileSync(outputFile, output);
             }
             if (doUpload) {
                 yield uploadSbomArtifact(output);

--- a/dist/downloadSyft/index.js
+++ b/dist/downloadSyft/index.js
@@ -24237,10 +24237,6 @@ function uploadSbomArtifact(contents) {
         const filePath = `${tempDir}/${fileName}`;
         fs.writeFileSync(filePath, contents);
         const retentionDays = parseInt(core.getInput("upload-artifact-retention"));
-        const outputFile = core.getInput("output-file");
-        if (outputFile) {
-            fs.copyFileSync(filePath, outputFile);
-        }
         core.info((0, GithubClient_1.dashWrap)("Uploading workflow artifacts"));
         core.info(filePath);
         yield client.uploadWorkflowArtifact({
@@ -24321,6 +24317,10 @@ function runSyftAction() {
             const priorArtifact = process.env[PRIOR_ARTIFACT_ENV_VAR];
             if (priorArtifact) {
                 core.debug(`Prior artifact: ${priorArtifact}`);
+            }
+            const outputFile = core.getInput("output-file");
+            if (outputFile) {
+                fs.writeFileSync(outputFile, output);
             }
             if (doUpload) {
                 yield uploadSbomArtifact(output);

--- a/dist/runSyftAction/index.js
+++ b/dist/runSyftAction/index.js
@@ -24189,10 +24189,6 @@ function uploadSbomArtifact(contents) {
         const filePath = `${tempDir}/${fileName}`;
         fs.writeFileSync(filePath, contents);
         const retentionDays = parseInt(core.getInput("upload-artifact-retention"));
-        const outputFile = core.getInput("output-file");
-        if (outputFile) {
-            fs.copyFileSync(filePath, outputFile);
-        }
         core.info((0, GithubClient_1.dashWrap)("Uploading workflow artifacts"));
         core.info(filePath);
         yield client.uploadWorkflowArtifact({
@@ -24273,6 +24269,10 @@ function runSyftAction() {
             const priorArtifact = process.env[PRIOR_ARTIFACT_ENV_VAR];
             if (priorArtifact) {
                 core.debug(`Prior artifact: ${priorArtifact}`);
+            }
+            const outputFile = core.getInput("output-file");
+            if (outputFile) {
+                fs.writeFileSync(outputFile, output);
             }
             if (doUpload) {
                 yield uploadSbomArtifact(output);

--- a/src/github/SyftGithubAction.ts
+++ b/src/github/SyftGithubAction.ts
@@ -14,9 +14,9 @@ import { SyftOptions } from "../Syft";
 import { VERSION } from "../SyftVersion";
 import { execute } from "./Executor";
 import {
+  DependencySnapshot,
   dashWrap,
   debugLog,
-  DependencySnapshot,
   getClient,
 } from "./GithubClient";
 import { downloadSyftFromZip } from "./SyftDownloader";
@@ -282,11 +282,6 @@ export async function uploadSbomArtifact(contents: string): Promise<void> {
 
   const retentionDays = parseInt(core.getInput("upload-artifact-retention"));
 
-  const outputFile = core.getInput("output-file");
-  if (outputFile) {
-    fs.copyFileSync(filePath, outputFile);
-  }
-
   core.info(dashWrap("Uploading workflow artifacts"));
   core.info(filePath);
 
@@ -382,6 +377,11 @@ export async function runSyftAction(): Promise<void> {
     const priorArtifact = process.env[PRIOR_ARTIFACT_ENV_VAR];
     if (priorArtifact) {
       core.debug(`Prior artifact: ${priorArtifact}`);
+    }
+
+    const outputFile = core.getInput("output-file");
+    if (outputFile) {
+      fs.writeFileSync(outputFile, output);
     }
 
     if (doUpload) {


### PR DESCRIPTION
Before this, the sbom file would only be copied to `output-file` if `upload-artifact` is true. However, the file may still be useful if upload is not enabled.