### PR TITLE
chore: test natively on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,11 +30,6 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: Vampire/setup-wsl@v2
-        if: ${{ matrix.os == 'windows-latest' }}
-        with:
-          distribution: Alpine
-
       - uses: actions/checkout@v3
         with:
           path: ./


### PR DESCRIPTION
Previously, parts of the tooling didn't work on Windows, so WSL was used as a workaround for this use case. Things should work on Windows now, so test running directly instead of via WSL.