### PR TITLE
chore: fix github-script invocation

### DIFF
--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -23,7 +23,7 @@ jobs:
             }
             core.info(`Getting PR #${request.pull_number} from ${request.owner}/${request.repo}`)
             try {
-              const result = await github.pulls.get(request)
+              const result = await github.rest.pulls.get(request)
               return result.data
             } catch (err) {
               core.setFailed(`Request failed with error ${err}`)


### PR DESCRIPTION
According to the relesae notes, github.* API methods have been removed and should instead by accessed by github.rest.*. Use that method to access pull request information.

See https://github.com/marketplace/actions/github-script#v5