### PR TITLE
fix: reduce syft debug level

### DIFF
--- a/dist/attachReleaseAssets/index.js
+++ b/dist/attachReleaseAssets/index.js
@@ -24039,7 +24039,10 @@ function executeSyft(_a) {
             }
         }
         // https://github.com/anchore/syft#configuration
-        let args = ["packages", "-vv"];
+        let args = ["scan"];
+        if (core.isDebug()) {
+            args = [...args, "-vv"];
+        }
         if ("image" in input && input.image) {
             if (registryUser) {
                 args = [...args, `registry:${input.image}`];

--- a/dist/downloadSyft/index.js
+++ b/dist/downloadSyft/index.js
@@ -24087,7 +24087,10 @@ function executeSyft(_a) {
             }
         }
         // https://github.com/anchore/syft#configuration
-        let args = ["packages", "-vv"];
+        let args = ["scan"];
+        if (core.isDebug()) {
+            args = [...args, "-vv"];
+        }
         if ("image" in input && input.image) {
             if (registryUser) {
                 args = [...args, `registry:${input.image}`];

--- a/dist/runSyftAction/index.js
+++ b/dist/runSyftAction/index.js
@@ -24039,7 +24039,10 @@ function executeSyft(_a) {
             }
         }
         // https://github.com/anchore/syft#configuration
-        let args = ["packages", "-vv"];
+        let args = ["scan"];
+        if (core.isDebug()) {
+            args = [...args, "-vv"];
+        }
         if ("image" in input && input.image) {
             if (registryUser) {
                 args = [...args, `registry:${input.image}`];

--- a/src/github/SyftGithubAction.ts
+++ b/src/github/SyftGithubAction.ts
@@ -127,7 +127,11 @@ async function executeSyft({
   }
 
   // https://github.com/anchore/syft#configuration
-  let args = ["packages", "-vv"];
+  let args = ["scan"];
+
+  if (core.isDebug()) {
+    args = [...args, "-vv"];
+  }
 
   if ("image" in input && input.image) {
     if (registryUser) {

--- a/tests/SyftGithubAction.test.ts
+++ b/tests/SyftGithubAction.test.ts
@@ -65,8 +65,8 @@ describe("Action", () => {
     const { args } = data.execArgs;
 
     expect(args).toBeDefined()
-    expect(args.length > 2).toBeTruthy();
-    expect(args[2]).toBe("some-image:latest")
+    expect(args.length > 1).toBeTruthy();
+    expect(args[1]).toBe("some-image:latest")
   });
 
   it("runs with path input", async () => {
@@ -81,8 +81,8 @@ describe("Action", () => {
     const { args } = data.execArgs;
 
     expect(args).toBeDefined()
-    expect(args.length > 2).toBeTruthy();
-    expect(args[2]).toBe("dir:some-path")
+    expect(args.length > 1).toBeTruthy();
+    expect(args[1]).toBe("dir:some-path")
   });
 
   it("runs with file input", async () => {
@@ -97,8 +97,8 @@ describe("Action", () => {
     const { args } = data.execArgs;
 
     expect(args).toBeDefined()
-    expect(args.length > 2).toBeTruthy();
-    expect(args[2]).toBe("file:some-file.jar")
+    expect(args.length > 1).toBeTruthy();
+    expect(args[1]).toBe("file:some-file.jar")
   });
 
   it("runs with release uploads inputs", async () => {


### PR DESCRIPTION
When executing Syft, we don't need to have debug logging enabled by default.

Fixes #445