### PR TITLE
fix: don't pass in a separate env. This makes it impossible to pass env vars via the action context to syft.

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -8,6 +8,10 @@ If you would like to get more extensive debug logging, it is
 possible to enable this as [described here](https://github.com/actions/toolkit/blob/master/docs/action-debugging.md)
 by setting a secret in your repository of `ACTIONS_STEP_DEBUG` to `true`.
 
+## Update `dist/`
+
+Updates to `dist/` and handled via a commit hook. Install the hook by running `npm install`.
+
 ## Tests
 
 To run tests locally, you will need a local docker instance and registry along with a few

--- a/dist/attachReleaseAssets/index.js
+++ b/dist/attachReleaseAssets/index.js
@@ -24024,9 +24024,7 @@ function executeSyft(_a) {
     return __awaiter(this, void 0, void 0, function* () {
         let stdout = "";
         const cmd = yield getSyftCommand();
-        const env = {
-            SYFT_CHECK_FOR_APP_UPDATE: "false",
-        };
+        const env = Object.assign(Object.assign({}, process.env), { SYFT_CHECK_FOR_APP_UPDATE: "false" });
         const registryUser = core.getInput("registry-username");
         const registryPass = core.getInput("registry-password");
         if (registryUser) {

--- a/dist/downloadSyft/index.js
+++ b/dist/downloadSyft/index.js
@@ -24072,9 +24072,7 @@ function executeSyft(_a) {
     return __awaiter(this, void 0, void 0, function* () {
         let stdout = "";
         const cmd = yield getSyftCommand();
-        const env = {
-            SYFT_CHECK_FOR_APP_UPDATE: "false",
-        };
+        const env = Object.assign(Object.assign({}, process.env), { SYFT_CHECK_FOR_APP_UPDATE: "false" });
         const registryUser = core.getInput("registry-username");
         const registryPass = core.getInput("registry-password");
         if (registryUser) {

--- a/dist/runSyftAction/index.js
+++ b/dist/runSyftAction/index.js
@@ -24024,9 +24024,7 @@ function executeSyft(_a) {
     return __awaiter(this, void 0, void 0, function* () {
         let stdout = "";
         const cmd = yield getSyftCommand();
-        const env = {
-            SYFT_CHECK_FOR_APP_UPDATE: "false",
-        };
+        const env = Object.assign(Object.assign({}, process.env), { SYFT_CHECK_FOR_APP_UPDATE: "false" });
         const registryUser = core.getInput("registry-username");
         const registryPass = core.getInput("registry-password");
         if (registryUser) {

--- a/src/github/SyftGithubAction.ts
+++ b/src/github/SyftGithubAction.ts
@@ -108,17 +108,16 @@ async function executeSyft({
 
   const cmd = await getSyftCommand();
 
-  const env: { [key: string]: string } = {
-    SYFT_CHECK_FOR_APP_UPDATE: "false",
-  };
+
+  process.env.SYFT_CHECK_FOR_APP_UPDATE = "false"
 
   const registryUser = core.getInput("registry-username");
   const registryPass = core.getInput("registry-password");
 
   if (registryUser) {
-    env.SYFT_REGISTRY_AUTH_USERNAME = registryUser;
+    process.env.SYFT_REGISTRY_AUTH_USERNAME = registryUser;
     if (registryPass) {
-      env.SYFT_REGISTRY_AUTH_PASSWORD = registryPass;
+      process.env.SYFT_REGISTRY_AUTH_PASSWORD = registryPass;
     } else {
       core.warning(
         "WARNING: registry-username specified without registry-password"
@@ -172,7 +171,6 @@ async function executeSyft({
 
   const exitCode = await core.group("Executing Syft...", async () =>
     execute(cmd, args, {
-      env,
       outStream,
       listeners: {
         stdout(buffer) {

--- a/src/github/SyftGithubAction.ts
+++ b/src/github/SyftGithubAction.ts
@@ -108,16 +108,18 @@ async function executeSyft({
 
   const cmd = await getSyftCommand();
 
-
-  process.env.SYFT_CHECK_FOR_APP_UPDATE = "false"
+  const env: { [key: string]: string } = {
+    ...process.env,
+    SYFT_CHECK_FOR_APP_UPDATE: "false",
+  };
 
   const registryUser = core.getInput("registry-username");
   const registryPass = core.getInput("registry-password");
 
   if (registryUser) {
-    process.env.SYFT_REGISTRY_AUTH_USERNAME = registryUser;
+    env.SYFT_REGISTRY_AUTH_USERNAME = registryUser;
     if (registryPass) {
-      process.env.SYFT_REGISTRY_AUTH_PASSWORD = registryPass;
+      env.SYFT_REGISTRY_AUTH_PASSWORD = registryPass;
     } else {
       core.warning(
         "WARNING: registry-username specified without registry-password"
@@ -171,6 +173,7 @@ async function executeSyft({
 
   const exitCode = await core.group("Executing Syft...", async () =>
     execute(cmd, args, {
+      env,
       outStream,
       listeners: {
         stdout(buffer) {


### PR DESCRIPTION
Signed-off-by: Noah Krause <krausenoah@gmail.com>
