### PR TITLE
chore: track script to make local test images

### DIFF
--- a/build-test-images.sh
+++ b/build-test-images.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+export PLATFORM="linux/amd64"
+
+docker run -d -p 5000:5000 --name registry registry:2
+
+for distro in alpine centos debian; do
+  docker build --platform="${PLATFORM}" -t "localhost:5000/match-coverage/${distro}:latest" "./tests/fixtures/image-$distro-match-coverage"
+  docker push "localhost:5000/match-coverage/${distro}:latest"
+done
+


### PR DESCRIPTION
Can be used for local development. Might be worth integrating into npm commands.

Remembering to start the local registry before running tests locally is cumbersome. Here's a shell script, copied essential from the docs, to do it for us.

Questions:

1.  Should this script be instead moved to an npm target?
2. Should this script be extracted from test setup into its own task?
3. How should we handle failure modes, e.g. where there's already a container named `registry` or a port is in use?
4. Should we totally dispense with the local registry and just push test images to a container registry somewhere?

PR is a conversation starter, in other words. But this script has been kicking around locally for a while and I use it, so I wanted to share.