### PR TITLE
chore: serialize tests to prevent install race

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "package:download-action": "ncc build src/attachReleaseAssets.ts -o dist/attachReleaseAssets",
     "package:release-action": "ncc build src/downloadSyft.ts -o dist/downloadSyft",
     "post-package:fix-line-endings": "eolConverter 'dist/**/*.js'",
-    "test": "jest --collect-coverage",
+    "test": "jest --collect-coverage --runInBand",
     "test:update-snapshots": "jest --updateSnapshot",
     "all": "npm run build && npm run format && npm run lint && npm run package && npm test",
     "prepare": "husky install",


### PR DESCRIPTION
Previously, running the npm test script in CI would sometimes result in multiple test processes all trying to install Syft at the same time, and one would fail with "span: ETXTBSY". Instead, run all tests in series.

See https://jestjs.io/docs/cli#--runinband

See anchore/scan-action#265