### PR TITLE
Update README to include bit about permissions near the top

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@ and upload a workflow artifact SBOM in SPDX format. It will also detect
 if being run during a [GitHub release](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases)
 and upload the SBOM as a release asset.
 
+> [!IMPORTANT]
+> To upload the SBOM to releases, you will need to give the action permission to read the artifact from the action, and write it to the release:
+> ```yaml
+> jobs:
+>  build:
+>    permissions:
+>      actions: read
+>      contents: write
+>    steps:
+> ```
+
 ## Example Usage
 
 ### Scan a container image


### PR DESCRIPTION
Currently the info about permissions is below the fold, and I missed it when implementing the action for my own projects.