### PR TITLE
fix: Catch zip download errors to proceed with other methods

### DIFF
--- a/src/github/SyftDownloader.ts
+++ b/src/github/SyftDownloader.ts
@@ -27,6 +27,9 @@ export async function downloadSyftFromZip(url: string): Promise<string> {
       // go build -o syftbin
       await execute("go", ["build", "-o", "syftbin"]);
       return `${repoDir}/syftbin`;
+    } catch {
+      // Catch the error but do nothing with it so the remaining
+      // download code will run instead of the action crashing
     } finally {
       process.chdir(cwd);
     }


### PR DESCRIPTION
The `try/finally` wrapping the Syft zip download doesn't have a catch, so if the download fails, the entire action crashes. This adds an empty catch so the other methods for installing Syft will be tried instead of the action failing.