### PR TITLE
feat: Add new sub-action "upload-github-snapshot" & action input "dependency-snapshot-output-file"

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ Use the `file` parameter, relative to the repository root:
     file: ./build/file
 ```
 
+### Generate Github Dependency Snapshot without uploading
+
+Use the `dependency-snapshot-output-file` parameter, relative to the repository root:
+
+```yaml
+- uses: anchore/sbom-action@v0
+  with:
+    dependency-snapshot-output-file: ./dependency-snapshot.github.sbom.json
+```
+
 ### Publishing SBOMs with releases
 
 The `sbom-action` will detect being run during a
@@ -154,23 +164,24 @@ actions: read # to find workflow artifacts when attaching release assets
 The main [SBOM action](action.yml), responsible for generating SBOMs
 and uploading them as workflow artifacts and release assets.
 
-| Parameter                   | Description                                                                                                                                             | Default                          |
-| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
-| `path`                      | A path on the filesystem to scan. This is mutually exclusive to `file` and `image`.                                                                     | \<current directory>             |
-| `file`                      | A file on the filesystem to scan. This is mutually exclusive to `path` and `image`.                                                                     |                                  |
-| `image`                     | A container image to scan. This is mutually exclusive to `path` and `file`. See [Scan a container image](#scan-a-container-image) for more information. |                                  |
-| `registry-username`         | The registry username to use when authenticating to an external registry                                                                                |                                  |
-| `registry-password`         | The registry password to use when authenticating to an external registry                                                                                |                                  |
-| `artifact-name`             | The name to use for the generated SBOM artifact. See: [Naming the SBOM output](#naming-the-sbom-output)                                                 | `sbom-<job>-<step-id>.spdx.json` |
-| `output-file`               | The location to output a resulting SBOM                                                                                                                 |                                  |
-| `format`                    | The SBOM format to export. One of: `spdx`, `spdx-json`, `cyclonedx`, `cyclonedx-json`                                                                   | `spdx-json`                      |
-| `dependency-snapshot`       | Whether to upload the SBOM to the GitHub Dependency submission API                                                                                      | `false`                          |
-| `upload-artifact`           | Upload artifact to workflow                                                                                                                             | `true`                           |
-| `upload-artifact-retention` | Retention policy in days for uploaded artifact to workflow.                                                                                             |                                  |
-| `upload-release-assets`     | Upload release assets                                                                                                                                   | `true`                           |
-| `syft-version`              | The version of Syft to use                                                                                                                              |                                  |
-| `github-token`              | Authorized secret GitHub Personal Access Token.                                                                                                         | `github.token`                   |
-| `config `                   | Syft configuration file to use.                                                                                                                         |                                  |
+| Parameter                         | Description                                                                                                                                             | Default                          |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
+| `path`                            | A path on the filesystem to scan. This is mutually exclusive to `file` and `image`.                                                                     | \<current directory>             |
+| `file`                            | A file on the filesystem to scan. This is mutually exclusive to `path` and `image`.                                                                     |                                  |
+| `image`                           | A container image to scan. This is mutually exclusive to `path` and `file`. See [Scan a container image](#scan-a-container-image) for more information. |                                  |
+| `registry-username`               | The registry username to use when authenticating to an external registry                                                                                |                                  |
+| `registry-password`               | The registry password to use when authenticating to an external registry                                                                                |                                  |
+| `artifact-name`                   | The name to use for the generated SBOM artifact. See: [Naming the SBOM output](#naming-the-sbom-output)                                                 | `sbom-<job>-<step-id>.spdx.json` |
+| `output-file`                     | The location to output a resulting SBOM                                                                                                                 |                                  |
+| `format`                          | The SBOM format to export. One of: `spdx`, `spdx-json`, `cyclonedx`, `cyclonedx-json`                                                                   | `spdx-json`                      |
+| `dependency-snapshot`             | Whether to upload the SBOM to the GitHub Dependency submission API                                                                                      | `false`                          |
+| `dependency-snapshot-output-file` | The location to output dependency snapshot file                                                                                                         |                                  |
+| `upload-artifact`                 | Upload artifact to workflow                                                                                                                             | `true`                           |
+| `upload-artifact-retention`       | Retention policy in days for uploaded artifact to workflow.                                                                                             |                                  |
+| `upload-release-assets`           | Upload release assets                                                                                                                                   | `true`                           |
+| `syft-version`                    | The version of Syft to use                                                                                                                              |                                  |
+| `github-token`                    | Authorized secret GitHub Personal Access Token.                                                                                                         | `github.token`                   |
+| `config `                         | Syft configuration file to use.                                                                                                                         |                                  |
 
 ### anchore/sbom-action/publish-sbom
 

--- a/README.md
+++ b/README.md
@@ -78,14 +78,70 @@ Use the `file` parameter, relative to the repository root:
     file: ./build/file
 ```
 
-### Generate Github Dependency Snapshot without uploading
+### Generate Github dependency snapshot without uploading
 
 Use the `dependency-snapshot-output-file` parameter, relative to the repository root:
 
 ```yaml
 - uses: anchore/sbom-action@v0
   with:
+    file: ./build/file
     dependency-snapshot-output-file: ./dependency-snapshot.github.sbom.json
+```
+
+### Upload Github dependency snapshot
+Use the `dependency-snapshot-input-file` parameter, relative to the repository root:
+
+> [!IMPORTANT]
+> To upload the dependency snapshot to Github requires permission `contents: write`
+
+```yaml
+ jobs:
+ run-sbom:
+    permissions:
+     contents: write 
+    steps:
+    - uses: anchore/sbom-action/upload-github-snapshot@v0
+      with:
+        file: ./build/file
+        dependency-snapshot-input-file: ./dependency-snapshot.github.sbom.json
+```
+
+### Upload Github Dependency Snapshot when event triggered on default branch
+
+> [!IMPORTANT]
+> Uploading dependency snapshot to Github requires permission `contents: write` to the Github token.
+
+```yaml
+ jobs:
+ run-sbom:
+    permissions:
+     actions: read
+     contents: read 
+    steps:
+    - uses: anchore/sbom-action@v0
+      with:
+        file: ./build/file
+        dependency-snapshot-output-file: ./dependency-snapshot.github.sbom.json
+    - name: Upload dependency snapshot
+      uses: actions/upload-artifact@v7
+      with:
+        archive: false # upload individual file to artifacts
+        path: ./dependency-snapshot.github.sbom.json
+  dependency-snapshot:
+    ...
+    if: github.ref_name == github.event.repository.default_branch
+    permissions:
+     actions: read
+     contents: write
+    steps:
+    - name: Download dependency snapshot
+      uses: actions/download-artifact@v8
+      with:
+        name: dependency-snapshot.github.sbom.json
+    - uses: anchore/sbom-action/upload-github-snapshot@v0
+      with:
+        dependency-snapshot-input-file: ./dependency-snapshot.github.sbom.json
 ```
 
 ### Publishing SBOMs with releases
@@ -207,6 +263,15 @@ Output parameters:
 
 `cmd` can be referenced in a workflow like other output parameters:
 `${{ steps.<step-id>.outputs.cmd }}`
+
+## anchore/sbom-action/upload-github-snapshot
+
+A sub-action to [upload dependency snapshot](upload-github-snapshot/action.yml) to Github.
+
+| Parameter                        | Description                                                         | Default |
+| -------------------------------- | ------------------------------------------------------------------- | ------- |
+| `dependency-snapshot-input-file` | Dependency snapshot path on the filesystem to upload to Github API. |         |
+
 
 ## Windows
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ Use the `dependency-snapshot-input-file` parameter, relative to the repository r
     steps:
     - uses: anchore/sbom-action/upload-github-snapshot@v0
       with:
-        file: ./build/file
         dependency-snapshot-input-file: ./dependency-snapshot.github.sbom.json
 ```
 
@@ -131,6 +130,7 @@ Use the `dependency-snapshot-input-file` parameter, relative to the repository r
   dependency-snapshot:
     ...
     if: github.ref_name == github.event.repository.default_branch
+    needs: [run-sbom]
     permissions:
      actions: read
      contents: write

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,10 @@ inputs:
     required: false
     description: "The version of Syft to use"
 
+  dependency-snapshot-output-file:
+    required: false
+    description: "A file location to output dependency snapshot file"
+
   dependency-snapshot:
     required: false
     description: "Upload to GitHub dependency snapshot API"

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -96543,6 +96543,7 @@ async function executeSyft({
   };
   const registryUser = getInput("registry-username");
   const registryPass = getInput("registry-password");
+  const dependencySnapshotOutputFile = getInput("dependency-snapshot-output-file");
   if (registryUser) {
     env.SYFT_REGISTRY_AUTH_USERNAME = registryUser;
     if (registryPass) {
@@ -96573,6 +96574,9 @@ async function executeSyft({
   args = [...args, "-o", format];
   if (opts.uploadToDependencySnapshotAPI) {
     args = [...args, "-o", `github=${githubDependencySnapshotFile}`];
+  }
+  if (dependencySnapshotOutputFile) {
+    args = [...args, "-o", `github=${dependencySnapshotOutputFile}`];
   }
   if (opts.configFile) {
     args = [...args, "-c", opts.configFile];

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -96723,8 +96723,11 @@ async function comparePullRequestTargetArtifact() {
     }
   }
 }
+function dependencySnapshotRun() {
+  return getInput("run") === "upload-github-snapshot";
+}
 function uploadToSnapshotAPI() {
-  return getBooleanInput("dependency-snapshot", false);
+  return dependencySnapshotRun() ? true : getBooleanInput("dependency-snapshot", false);
 }
 async function runSyftAction() {
   info(dashWrap("Running SBOM Action"));
@@ -96764,17 +96767,18 @@ async function uploadDependencySnapshot() {
   if (!uploadToSnapshotAPI()) {
     return;
   }
-  if (!fs11.existsSync(githubDependencySnapshotFile)) {
-    warning(
-      `No dependency snapshot found at '${githubDependencySnapshotFile}'`
-    );
-    return;
+  const dependencySnapshotFile = getInput("dependency-snapshot-input-file") || githubDependencySnapshotFile;
+  if (!fs11.existsSync(dependencySnapshotFile)) {
+    const message = `No dependency snapshot found at '${dependencySnapshotFile}'`;
+    if (dependencySnapshotRun())
+      return setFailed(message);
+    return warning(message);
   }
   const { workflow, job, runId, repo: repo2, ref } = context2;
   const sha = getSha();
   const client2 = getClient2(repo2, getInput("github-token"));
   const snapshot2 = JSON.parse(
-    fs11.readFileSync(githubDependencySnapshotFile).toString("utf8")
+    fs11.readFileSync(dependencySnapshotFile).toString("utf8")
   );
   let correlator = `${workflow}_${job}`;
   const artifactInput = getArtifactNameInput();
@@ -96790,7 +96794,7 @@ async function uploadDependencySnapshot() {
   snapshot2.sha = sha;
   snapshot2.ref = ref;
   info(
-    `Uploading GitHub dependency snapshot from ${githubDependencySnapshotFile}`
+    `Uploading GitHub dependency snapshot from ${dependencySnapshotFile}`
   );
   debugLog("Snapshot:", snapshot2);
   await client2.postDependencySnapshot(snapshot2);
@@ -96914,6 +96918,9 @@ runAndFailBuildOnException(async () => {
     }
     case "publish-sbom":
       await attachReleaseAssets();
+      break;
+    case "upload-github-snapshot":
+      await uploadDependencySnapshot();
       break;
     default:
       throw new Error(`Unknown run mode: '${run}'`);

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -96479,7 +96479,6 @@ var SYFT_BINARY_NAME = "syft";
 var SYFT_VERSION = getInput("syft-version") || VERSION7;
 var PRIOR_ARTIFACT_ENV_VAR = "ANCHORE_SBOM_ACTION_PRIOR_ARTIFACT";
 var tempDir = fs11.mkdtempSync(import_path4.default.join(import_os7.default.tmpdir(), "sbom-action-"));
-var githubDependencySnapshotFile = `${tempDir}/github.sbom.json`;
 var exeSuffix = process.platform == "win32" ? ".exe" : "";
 function getArtifactName() {
   const fileName = getArtifactNameInput();
@@ -96530,6 +96529,13 @@ function getArtifactName() {
 function getArtifactNameInput() {
   return getInput("artifact-name");
 }
+function getGitHubDependencySnapshotPath() {
+  const inputPath = getInput("dependency-snapshot-output-file");
+  if (inputPath) {
+    return inputPath;
+  }
+  return import_path4.default.join(tempDir, "github.sbom.json");
+}
 async function executeSyft({
   input,
   format,
@@ -96544,6 +96550,7 @@ async function executeSyft({
   const registryUser = getInput("registry-username");
   const registryPass = getInput("registry-password");
   const dependencySnapshotOutputFile = getInput("dependency-snapshot-output-file");
+  const githubSnapshotPath = getGitHubDependencySnapshotPath();
   if (registryUser) {
     env.SYFT_REGISTRY_AUTH_USERNAME = registryUser;
     if (registryPass) {
@@ -96572,11 +96579,8 @@ async function executeSyft({
     throw new Error("Invalid input, no image or path specified");
   }
   args = [...args, "-o", format];
-  if (opts.uploadToDependencySnapshotAPI) {
-    args = [...args, "-o", `github=${githubDependencySnapshotFile}`];
-  }
-  if (dependencySnapshotOutputFile) {
-    args = [...args, "-o", `github=${dependencySnapshotOutputFile}`];
+  if (opts.uploadToDependencySnapshotAPI || dependencySnapshotOutputFile) {
+    args = [...args, "-o", `github=${githubSnapshotPath}`];
   }
   if (opts.configFile) {
     args = [...args, "-c", opts.configFile];
@@ -96723,11 +96727,8 @@ async function comparePullRequestTargetArtifact() {
     }
   }
 }
-function dependencySnapshotRun() {
-  return getInput("run") === "upload-github-snapshot";
-}
 function uploadToSnapshotAPI() {
-  return dependencySnapshotRun() ? true : getBooleanInput("dependency-snapshot", false);
+  return getInput("run") === "upload-github-snapshot" || getBooleanInput("dependency-snapshot", false);
 }
 async function runSyftAction() {
   info(dashWrap("Running SBOM Action"));
@@ -96767,12 +96768,9 @@ async function uploadDependencySnapshot() {
   if (!uploadToSnapshotAPI()) {
     return;
   }
-  const dependencySnapshotFile = getInput("dependency-snapshot-input-file") || githubDependencySnapshotFile;
+  const dependencySnapshotFile = getInput("dependency-snapshot-input-file") || getGitHubDependencySnapshotPath();
   if (!fs11.existsSync(dependencySnapshotFile)) {
-    const message = `No dependency snapshot found at '${dependencySnapshotFile}'`;
-    if (dependencySnapshotRun())
-      return setFailed(message);
-    return warning(message);
+    return setFailed(`No dependency snapshot found at '${dependencySnapshotFile}'`);
   }
   const { workflow, job, runId, repo: repo2, ref } = context2;
   const sha = getSha();

--- a/llms.txt
+++ b/llms.txt
@@ -51,5 +51,5 @@ Scan container image:
 - `/src/` - TypeScript source code
 - `/dist/` - Compiled JavaScript for distribution
 - `/tests/` - Test files and fixtures
-- `/download-syft/`, `/publish-sbom/` - Sub-actions
+- `/download-syft/`, `/publish-sbom/`, `/upload-github-snapshot/` - Sub-actions
 - `action.yml` - Main action configuration

--- a/src/github/GithubClient.ts
+++ b/src/github/GithubClient.ts
@@ -423,7 +423,7 @@ export class GithubClient {
       );
 
       if (response.status >= 400) {
-        core.warning(
+        core.error(
           `Dependency snapshot upload failed: ${stringify(response)}`,
         );
       } else {
@@ -434,7 +434,7 @@ export class GithubClient {
       if ("response" in e) {
         v = e.response;
       }
-      core.warning(`Error uploading depdendency snapshot: ${stringify(v)}`);
+      core.error(`Error uploading depdendency snapshot: ${stringify(v)}`);
     }
   }
 }

--- a/src/github/SyftGithubAction.ts
+++ b/src/github/SyftGithubAction.ts
@@ -122,6 +122,7 @@ async function executeSyft({
 
   const registryUser = core.getInput("registry-username");
   const registryPass = core.getInput("registry-password");
+  const dependencySnapshotOutputFile = core.getInput("dependency-snapshot-output-file");
 
   if (registryUser) {
     env.SYFT_REGISTRY_AUTH_USERNAME = registryUser;
@@ -160,6 +161,10 @@ async function executeSyft({
   if (opts.uploadToDependencySnapshotAPI) {
     // generate github dependency format
     args = [...args, "-o", `github=${githubDependencySnapshotFile}`];
+  }
+
+  if (dependencySnapshotOutputFile) {
+    args = [...args, "-o", `github=${dependencySnapshotOutputFile}`];
   }
 
   if (opts.configFile) {

--- a/src/github/SyftGithubAction.ts
+++ b/src/github/SyftGithubAction.ts
@@ -382,8 +382,12 @@ async function comparePullRequestTargetArtifact(): Promise<void> {
   }
 }
 
+function dependencySnapshotRun() {
+  return core.getInput("run") === "upload-github-snapshot";
+}
+
 function uploadToSnapshotAPI() {
-  return getBooleanInput("dependency-snapshot", false);
+  return dependencySnapshotRun() ? true : getBooleanInput("dependency-snapshot", false);
 }
 
 export async function runSyftAction(): Promise<void> {
@@ -441,18 +445,22 @@ export async function uploadDependencySnapshot(): Promise<void> {
     return;
   }
 
-  if (!fs.existsSync(githubDependencySnapshotFile)) {
-    core.warning(
-      `No dependency snapshot found at '${githubDependencySnapshotFile}'`,
-    );
-    return;
+  const dependencySnapshotFile = core.getInput("dependency-snapshot-input-file") || githubDependencySnapshotFile;
+
+  if (!fs.existsSync(dependencySnapshotFile)) {
+    const message = `No dependency snapshot found at '${dependencySnapshotFile}'`;
+
+    if (dependencySnapshotRun())
+      return core.setFailed(message);
+
+    return core.warning(message);
   }
   const { workflow, job, runId, repo, ref } = github.context;
   const sha = getSha();
   const client = getClient(repo, core.getInput("github-token"));
 
   const snapshot = JSON.parse(
-    fs.readFileSync(githubDependencySnapshotFile).toString("utf8"),
+    fs.readFileSync(dependencySnapshotFile).toString("utf8"),
   ) as DependencySnapshot;
 
   let correlator = `${workflow}_${job}`;
@@ -476,7 +484,7 @@ export async function uploadDependencySnapshot(): Promise<void> {
   snapshot.ref = ref;
 
   core.info(
-    `Uploading GitHub dependency snapshot from ${githubDependencySnapshotFile}`,
+    `Uploading GitHub dependency snapshot from ${dependencySnapshotFile}`,
   );
   debugLog("Snapshot:", snapshot);
 

--- a/src/github/SyftGithubAction.ts
+++ b/src/github/SyftGithubAction.ts
@@ -28,7 +28,6 @@ export const SYFT_VERSION = core.getInput("syft-version") || VERSION;
 const PRIOR_ARTIFACT_ENV_VAR = "ANCHORE_SBOM_ACTION_PRIOR_ARTIFACT";
 
 const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "sbom-action-"));
-const githubDependencySnapshotFile = `${tempDir}/github.sbom.json`;
 
 const exeSuffix = process.platform == "win32" ? ".exe" : "";
 
@@ -100,6 +99,14 @@ function getArtifactNameInput() {
   return core.getInput("artifact-name");
 }
 
+function getGitHubDependencySnapshotPath(): string {
+  const inputPath = core.getInput("dependency-snapshot-output-file");
+  if (inputPath) {
+    return inputPath;
+  }
+  return path.join(tempDir, "github.sbom.json");
+}
+
 /**
  * Gets a reference to the syft command and executes the syft action
  * @param input syft input parameters
@@ -123,6 +130,7 @@ async function executeSyft({
   const registryUser = core.getInput("registry-username");
   const registryPass = core.getInput("registry-password");
   const dependencySnapshotOutputFile = core.getInput("dependency-snapshot-output-file");
+  const githubSnapshotPath = getGitHubDependencySnapshotPath();
 
   if (registryUser) {
     env.SYFT_REGISTRY_AUTH_USERNAME = registryUser;
@@ -158,13 +166,9 @@ async function executeSyft({
 
   args = [...args, "-o", format];
 
-  if (opts.uploadToDependencySnapshotAPI) {
+  if (opts.uploadToDependencySnapshotAPI || dependencySnapshotOutputFile) {
     // generate github dependency format
-    args = [...args, "-o", `github=${githubDependencySnapshotFile}`];
-  }
-
-  if (dependencySnapshotOutputFile) {
-    args = [...args, "-o", `github=${dependencySnapshotOutputFile}`];
+    args = [...args, "-o", `github=${githubSnapshotPath}`];
   }
 
   if (opts.configFile) {
@@ -382,12 +386,8 @@ async function comparePullRequestTargetArtifact(): Promise<void> {
   }
 }
 
-function dependencySnapshotRun() {
-  return core.getInput("run") === "upload-github-snapshot";
-}
-
 function uploadToSnapshotAPI() {
-  return dependencySnapshotRun() ? true : getBooleanInput("dependency-snapshot", false);
+  return core.getInput("run") === "upload-github-snapshot" || getBooleanInput("dependency-snapshot", false);
 }
 
 export async function runSyftAction(): Promise<void> {
@@ -445,16 +445,12 @@ export async function uploadDependencySnapshot(): Promise<void> {
     return;
   }
 
-  const dependencySnapshotFile = core.getInput("dependency-snapshot-input-file") || githubDependencySnapshotFile;
+  const dependencySnapshotFile = core.getInput("dependency-snapshot-input-file") || getGitHubDependencySnapshotPath();
 
   if (!fs.existsSync(dependencySnapshotFile)) {
-    const message = `No dependency snapshot found at '${dependencySnapshotFile}'`;
-
-    if (dependencySnapshotRun())
-      return core.setFailed(message);
-
-    return core.warning(message);
+    return core.setFailed(`No dependency snapshot found at '${dependencySnapshotFile}'`);
   }
+  
   const { workflow, job, runId, repo, ref } = github.context;
   const sha = getSha();
   const client = getClient(repo, core.getInput("github-token"));

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,9 @@ runAndFailBuildOnException(async () => {
     case "publish-sbom":
       await attachReleaseAssets();
       break;
+    case "upload-github-snapshot":
+      await uploadDependencySnapshot();
+      break;
     default:
       throw new Error(`Unknown run mode: '${run}'`);
   }

--- a/tests/integration/GitHubSnapshot.test.ts
+++ b/tests/integration/GitHubSnapshot.test.ts
@@ -2,7 +2,7 @@ import test, { describe, it, beforeEach, mock } from "node:test";
 import assert from "node:assert";
 import { context, getMocks } from "../mocks";
 
-const { setData, restoreInitialData, mocks } = getMocks(test);
+const { setData, restoreInitialData, mocks, data } = getMocks(test);
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
@@ -223,6 +223,90 @@ describe("GitHub Snapshot", { timeout: 30000 }, () => {
     // validate no request was made
     assert.equal(requestArgs, null);
   });
+
+  it("runs with input file", async (t) => {
+    const outputFile = `${fs.mkdtempSync(
+          path.join(os.tmpdir(), "sbom-action-")
+        )}/sbom-output.github.sbom.json`;
+
+    setData({
+      inputs: {
+        path: "tests/fixtures/npm-project",
+        "dependency-snapshot-output-file": outputFile,
+        "dependency-snapshot-input-file": outputFile,
+        "run": "upload-github-snapshot"
+      },
+      context: {  
+        ...context.push({
+          ref: "main",
+        }),
+        sha: "f293f09uaw90gwa09f9wea",
+        workflow: "my-workflow",
+        job: "default-import-job",
+        action: "__anchore_sbom-action",
+      },
+    });
+
+    await action.runSyftAction();
+
+    assert.ok(fs.existsSync(outputFile));
+    
+    await action.uploadDependencySnapshot();
+
+    // validate the request was made
+    assert.ok(requestArgs);
+    assert.equal(requestArgs.length, 2);
+    assert.equal(
+      requestArgs[0],
+      "POST /repos/test-org/test-repo/dependency-graph/snapshots"
+    );
+
+    // check the resulting snapshot file
+    const data = requestArgs[1].data;
+    const submission = JSON.parse(data);
+
+    assert.ok(submission.scanned);
+
+    // redact changing data
+    submission.scanned = "";
+    submission.detector.version = "";
+
+    assert.ok(submission.job);
+
+    t.assert.snapshot(submission);
+  });
+
+  it("fails with invalid input file", async () => {
+    const inputFile = `${fs.mkdtempSync(
+          path.join(os.tmpdir(), "sbom-action-")
+        )}/sbom-output.github.sbom.json`;
+
+    setData({
+      inputs: {
+        path: "tests/fixtures/npm-project",
+        "dependency-snapshot-input-file": inputFile,
+        "run": "upload-github-snapshot"
+      },
+      context: {  
+        ...context.push({
+          ref: "main",
+        }),
+        sha: "f293f09uaw90gwa09f9wea",
+        workflow: "my-workflow",
+        job: "default-import-job",
+        action: "__anchore_sbom-action",
+      },
+    });
+
+    assert.ok(!fs.existsSync(inputFile));
+    
+    await action.uploadDependencySnapshot();
+
+    // validate request was not made, and failed
+    assert.equal(requestArgs, null);
+    assert.equal(data.failed.message, `No dependency snapshot found at '${inputFile}'`)
+  });
+
 
   it("runs with dependency-snapshot-correlator defined", async (t) => {
     setData({

--- a/tests/integration/GitHubSnapshot.test.ts
+++ b/tests/integration/GitHubSnapshot.test.ts
@@ -3,6 +3,9 @@ import assert from "node:assert";
 import { context, getMocks } from "../mocks";
 
 const { setData, restoreInitialData, mocks } = getMocks(test);
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
 
 // actually run syft so we know if this output format is properly working
 delete mocks["@actions/tool-cache"];
@@ -40,6 +43,8 @@ const action = await import("../../src/github/SyftGithubAction");
 describe("GitHub Snapshot", { timeout: 30000 }, () => {
   beforeEach(() => {
     restoreInitialData();
+    // reset request state
+    requestArgs = null;
   });
 
   it("runs with default inputs", async (t) => {
@@ -135,6 +140,88 @@ describe("GitHub Snapshot", { timeout: 30000 }, () => {
     );
 
     t.assert.snapshot(submission);
+  });
+
+  it("runs with output file", async (t) => {
+    const outputFile = `${fs.mkdtempSync(
+          path.join(os.tmpdir(), "sbom-action-")
+        )}/sbom-output.github.sbom.json`;
+
+    setData({
+      inputs: {
+        path: "tests/fixtures/npm-project",
+        "dependency-snapshot-output-file": outputFile,
+        "dependency-snapshot": "true"
+      },
+      context: {  
+        ...context.push({
+          ref: "main",
+        }),
+        sha: "f293f09uaw90gwa09f9wea",
+        workflow: "my-workflow",
+        job: "default-import-job",
+        action: "__anchore_sbom-action",
+      },
+    });
+
+    await action.runSyftAction();
+
+    assert.ok(fs.existsSync(outputFile));
+    
+    await action.uploadDependencySnapshot();
+
+    // validate the request was made
+    assert.ok(requestArgs);
+    assert.equal(requestArgs.length, 2);
+    assert.equal(
+      requestArgs[0],
+      "POST /repos/test-org/test-repo/dependency-graph/snapshots"
+    );
+
+    // check the resulting snapshot file
+    const data = requestArgs[1].data;
+    const submission = JSON.parse(data);
+
+    assert.ok(submission.scanned);
+
+    // redact changing data
+    submission.scanned = "";
+    submission.detector.version = "";
+
+    assert.ok(submission.job);
+
+    t.assert.snapshot(submission);
+  });
+
+  it("runs with output file without upload", async () => {
+    const outputFile = `${fs.mkdtempSync(
+          path.join(os.tmpdir(), "sbom-action-")
+        )}/sbom-output.github.sbom.json`;
+
+    setData({
+      inputs: {
+        path: "tests/fixtures/npm-project",
+        "dependency-snapshot-output-file": outputFile,
+      },
+      context: {  
+        ...context.push({
+          ref: "main",
+        }),
+        sha: "f293f09uaw90gwa09f9wea",
+        workflow: "my-workflow",
+        job: "default-import-job",
+        action: "__anchore_sbom-action",
+      },
+    });
+
+    await action.runSyftAction();
+
+    assert.ok(fs.existsSync(outputFile));
+    
+    await action.uploadDependencySnapshot();
+
+    // validate no request was made
+    assert.equal(requestArgs, null);
   });
 
   it("runs with dependency-snapshot-correlator defined", async (t) => {

--- a/tests/integration/GitHubSnapshot.test.ts.snapshot
+++ b/tests/integration/GitHubSnapshot.test.ts.snapshot
@@ -276,3 +276,96 @@ exports[`GitHub Snapshot > runs with dependency-snapshot-correlator defined 1`] 
   "ref": "v0.0.0"
 }
 `;
+
+exports[`GitHub Snapshot > runs with output file 1`] = `
+{
+  "version": 0,
+  "job": {
+    "correlator": "my-workflow_default-import-job",
+    "id": "1"
+  },
+  "detector": {
+    "name": "syft",
+    "url": "https://github.com/anchore/syft",
+    "version": ""
+  },
+  "manifests": {
+    "tests/fixtures/npm-project/package-lock.json": {
+      "name": "tests/fixtures/npm-project/package-lock.json",
+      "file": {
+        "source_location": "tests/fixtures/npm-project/package-lock.json"
+      },
+      "resolved": {
+        "pkg:npm/chownr@2.0.0": {
+          "package_url": "pkg:npm/chownr@2.0.0",
+          "relationship": "direct",
+          "scope": "runtime"
+        },
+        "pkg:npm/fs-minipass@2.1.0": {
+          "package_url": "pkg:npm/fs-minipass@2.1.0",
+          "relationship": "direct",
+          "scope": "runtime"
+        },
+        "pkg:npm/js-tokens@4.0.0": {
+          "package_url": "pkg:npm/js-tokens@4.0.0",
+          "relationship": "direct",
+          "scope": "runtime"
+        },
+        "pkg:npm/loose-envify@1.4.0": {
+          "package_url": "pkg:npm/loose-envify@1.4.0",
+          "relationship": "direct",
+          "scope": "runtime"
+        },
+        "pkg:npm/minipass@3.1.3": {
+          "package_url": "pkg:npm/minipass@3.1.3",
+          "relationship": "direct",
+          "scope": "runtime"
+        },
+        "pkg:npm/minizlib@2.1.2": {
+          "package_url": "pkg:npm/minizlib@2.1.2",
+          "relationship": "direct",
+          "scope": "runtime"
+        },
+        "pkg:npm/mkdirp@1.0.4": {
+          "package_url": "pkg:npm/mkdirp@1.0.4",
+          "relationship": "direct",
+          "scope": "runtime"
+        },
+        "pkg:npm/object-assign@4.1.1": {
+          "package_url": "pkg:npm/object-assign@4.1.1",
+          "relationship": "direct",
+          "scope": "runtime"
+        },
+        "pkg:npm/prop-types@15.7.2": {
+          "package_url": "pkg:npm/prop-types@15.7.2",
+          "relationship": "direct",
+          "scope": "runtime"
+        },
+        "pkg:npm/react-is@16.13.1": {
+          "package_url": "pkg:npm/react-is@16.13.1",
+          "relationship": "direct",
+          "scope": "runtime"
+        },
+        "pkg:npm/react@16.14.0": {
+          "package_url": "pkg:npm/react@16.14.0",
+          "relationship": "direct",
+          "scope": "runtime"
+        },
+        "pkg:npm/tar@6.1.0": {
+          "package_url": "pkg:npm/tar@6.1.0",
+          "relationship": "direct",
+          "scope": "runtime"
+        },
+        "pkg:npm/yallist@4.0.0": {
+          "package_url": "pkg:npm/yallist@4.0.0",
+          "relationship": "direct",
+          "scope": "runtime"
+        }
+      }
+    }
+  },
+  "scanned": "",
+  "sha": "f293f09uaw90gwa09f9wea",
+  "ref": "v0.0.0"
+}
+`;

--- a/tests/integration/GitHubSnapshot.test.ts.snapshot
+++ b/tests/integration/GitHubSnapshot.test.ts.snapshot
@@ -277,6 +277,99 @@ exports[`GitHub Snapshot > runs with dependency-snapshot-correlator defined 1`] 
 }
 `;
 
+exports[`GitHub Snapshot > runs with input file 1`] = `
+{
+  "version": 0,
+  "job": {
+    "correlator": "my-workflow_default-import-job",
+    "id": "1"
+  },
+  "detector": {
+    "name": "syft",
+    "url": "https://github.com/anchore/syft",
+    "version": ""
+  },
+  "manifests": {
+    "tests/fixtures/npm-project/package-lock.json": {
+      "name": "tests/fixtures/npm-project/package-lock.json",
+      "file": {
+        "source_location": "tests/fixtures/npm-project/package-lock.json"
+      },
+      "resolved": {
+        "pkg:npm/chownr@2.0.0": {
+          "package_url": "pkg:npm/chownr@2.0.0",
+          "relationship": "direct",
+          "scope": "runtime"
+        },
+        "pkg:npm/fs-minipass@2.1.0": {
+          "package_url": "pkg:npm/fs-minipass@2.1.0",
+          "relationship": "direct",
+          "scope": "runtime"
+        },
+        "pkg:npm/js-tokens@4.0.0": {
+          "package_url": "pkg:npm/js-tokens@4.0.0",
+          "relationship": "direct",
+          "scope": "runtime"
+        },
+        "pkg:npm/loose-envify@1.4.0": {
+          "package_url": "pkg:npm/loose-envify@1.4.0",
+          "relationship": "direct",
+          "scope": "runtime"
+        },
+        "pkg:npm/minipass@3.1.3": {
+          "package_url": "pkg:npm/minipass@3.1.3",
+          "relationship": "direct",
+          "scope": "runtime"
+        },
+        "pkg:npm/minizlib@2.1.2": {
+          "package_url": "pkg:npm/minizlib@2.1.2",
+          "relationship": "direct",
+          "scope": "runtime"
+        },
+        "pkg:npm/mkdirp@1.0.4": {
+          "package_url": "pkg:npm/mkdirp@1.0.4",
+          "relationship": "direct",
+          "scope": "runtime"
+        },
+        "pkg:npm/object-assign@4.1.1": {
+          "package_url": "pkg:npm/object-assign@4.1.1",
+          "relationship": "direct",
+          "scope": "runtime"
+        },
+        "pkg:npm/prop-types@15.7.2": {
+          "package_url": "pkg:npm/prop-types@15.7.2",
+          "relationship": "direct",
+          "scope": "runtime"
+        },
+        "pkg:npm/react-is@16.13.1": {
+          "package_url": "pkg:npm/react-is@16.13.1",
+          "relationship": "direct",
+          "scope": "runtime"
+        },
+        "pkg:npm/react@16.14.0": {
+          "package_url": "pkg:npm/react@16.14.0",
+          "relationship": "direct",
+          "scope": "runtime"
+        },
+        "pkg:npm/tar@6.1.0": {
+          "package_url": "pkg:npm/tar@6.1.0",
+          "relationship": "direct",
+          "scope": "runtime"
+        },
+        "pkg:npm/yallist@4.0.0": {
+          "package_url": "pkg:npm/yallist@4.0.0",
+          "relationship": "direct",
+          "scope": "runtime"
+        }
+      }
+    }
+  },
+  "scanned": "",
+  "sha": "f293f09uaw90gwa09f9wea",
+  "ref": "v0.0.0"
+}
+`;
+
 exports[`GitHub Snapshot > runs with output file 1`] = `
 {
   "version": 0,

--- a/upload-github-snapshot/action.yml
+++ b/upload-github-snapshot/action.yml
@@ -1,0 +1,19 @@
+name: "Anchore SBOM Action / Upload Github dependency snapshot"
+description: "Uploads dependency snapshot to Github"
+author: "Anchore"
+
+inputs:
+  run:
+    required: true
+    description: "The action to run"
+    default: "upload-github-snapshot"
+    type: "choice"
+    options: ["upload-github-snapshot"]
+
+  dependency-snapshot-input-file:
+    required: true
+    description: "The file location to Github dependency snapshot file"
+
+runs:
+  using: "node24"
+  main: "../dist/index.cjs"

--- a/upload-github-snapshot/action.yml
+++ b/upload-github-snapshot/action.yml
@@ -14,6 +14,11 @@ inputs:
     required: true
     description: "The file location to Github dependency snapshot file"
 
+  github-token:
+    description: "Authorized secret GitHub Personal Access Token. Defaults to github.token"
+    required: false
+    default: ${{ github.token }}
+
 runs:
   using: "node24"
   main: "../dist/index.cjs"


### PR DESCRIPTION
## What is the goal of this pull request?
This pull requests adds a new sub-action to upload dependency snapshot, and  new action input 
`dependency-snapshot-output-file` to sbom-action. 

This is to allow users of sbom-action to reduce privilege used in jobs, and follow principle of least privilege.

## Changelog
* **sub-actions**
   * add sub-action `upload-github-snapshot`.
* **sbom-action**
  * add action input `dependency-snapshot-output-file`.
* **documentation**
  * add new sections for Github Dependency Snapshot
  * update sbom-action configuration table
  * add section for sub-action `anchore/sbom-action/upload-github-snapshot`
* **tests**
  * fix `requestArgs` not resetting after each Github Snapshot tests.
  * add new tests to cover new changes.
  
## Feedback Request
* Naming of the new sub-action and action input.
* Documentation improvements, and if anything is not clear/understandable.
* If there is missing tests, or other changes needed for this pull request to be merged.