### PR TITLE
Tighten workflow permissions and add CodeQL scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,14 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/*"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     cooldown:
       default-days: 7
+    open-pull-requests-limit: 10
 
   - package-ecosystem: "npm"
     directory: "/"
@@ -13,6 +16,7 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    open-pull-requests-limit: 10
     groups:
       dev-dependencies:
         dependency-type: "development"

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,61 @@
+# CodeQL scans for security vulnerabilities and coding errors across all
+# languages in this repo. Results appear in the "Security" tab under
+# "Code scanning alerts" and are enforced by branch protection rules.
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  # Weekly scheduled scan catches newly disclosed vulnerabilities in
+  # existing code, not just changes introduced by PRs.
+  schedule:
+    - cron: '38 11 * * 3'
+
+permissions: {}
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      # Required to upload SARIF results to the "Security" tab.
+      security-events: write
+      # Required to fetch internal or private CodeQL packs.
+      packages: read
+      # Only required for workflows in private repositories.
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # GitHub Actions workflow linting — no build needed.
+          - language: actions
+            build-mode: none
+
+          # JavaScript/TypeScript — no manual build needed for CodeQL analysis.
+          - language: javascript-typescript
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        with:
+          # The category tag lets GitHub associate SARIF results with the
+          # correct language when branch protection checks for required
+          # code scanning results.
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -5,8 +5,7 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   update_release_draft:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,12 +13,13 @@ on: # rebuild any PRs and main branch changes
       # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   build: # make sure build/ci work properly and there is no faked build ncc built scripts
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -34,6 +35,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -63,6 +66,8 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     services:
       registry:
         image: registry:2
@@ -86,6 +91,8 @@ jobs:
 
   test-as-action: # make sure the action works on a clean machine without building
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/update-syft-release.yml
+++ b/.github/workflows/update-syft-release.yml
@@ -7,12 +7,13 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   upgrade-syft:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: github.repository == 'anchore/sbom-action'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/validate-github-actions.yaml
+++ b/.github/workflows/validate-github-actions.yaml
@@ -10,8 +10,7 @@ on:
       - '.github/workflows/**'
       - '.github/actions/**'
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   zizmor:


### PR DESCRIPTION
Sets top-level workflow permissions to the empty map and pushes the minimum needed grants to each job. Also fixes the dependabot config and adds a CodeQL workflow for JavaScript/TypeScript and Actions analysis.

Changes:
- set `permissions: {}` at the top level of release-draft.yml, test.yml, update-syft-release.yml, and validate-github-actions.yaml
- add job-level `permissions: { contents: read }` where jobs previously inherited it from the top level
- dependabot: change github-actions interval from daily to weekly, add `.github/actions/*` directory, add `open-pull-requests-limit: 10` to both ecosystems
- add codeql.yaml workflow scanning javascript-typescript and actions on push/PR to main and weekly schedule
