### PR TITLE
Keep update-syft-release target name

### DIFF
--- a/.make/main.go
+++ b/.make/main.go
@@ -42,7 +42,7 @@ func main() {
 		// who can then commit the diff and open a PR by hand. Requires `gh`
 		// to be authenticated (gh auth login).
 		Task{
-			Name:        "update-syft",
+			Name:        "update-syft-release",
 			Description: "bump src/SyftVersion.ts to the latest syft release and rebuild dist/",
 			Run: func() {
 				version := strings.TrimSpace(Run(`gh release view --json name -q '.name' -R anchore/syft`))

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,4 +10,4 @@ make release
 
 ## Updating Syft
 
-`make update-syft` repins `src/SyftVersion.ts` and rebuilds `dist/` — review the diff and open a PR. Requires `gh` auth.
+`make update-syft-release` repins `src/SyftVersion.ts` and rebuilds `dist/` — review the diff and open a PR. Requires `gh` auth.


### PR DESCRIPTION
This restores the original target name before the go-make refactor