### PR TITLE
fix: retry transient syft download failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,14 @@ and upload the SBOM as a release asset.
 
 > [!IMPORTANT]
 > To upload the SBOM to releases, you will need to give the action permission to read the artifact from the action, and write it to the release:
+>
 > ```yaml
 > jobs:
->  build:
->    permissions:
->      actions: read
->      contents: write
->    steps:
+>   build:
+>     permissions:
+>       actions: read
+>       contents: write
+>     steps:
 > ```
 
 ## Example Usage
@@ -169,6 +170,8 @@ and uploading them as workflow artifacts and release assets.
 | `upload-artifact-retention` | Retention policy in days for uploaded artifact to workflow.                                                                                             |                                  |
 | `upload-release-assets`     | Upload release assets                                                                                                                                   | `true`                           |
 | `syft-version`              | The version of Syft to use                                                                                                                              |                                  |
+| `syft-download-retry-count` | Number of times to retry transient Syft download failures                                                                                               | `3`                              |
+| `syft-download-retry-delay` | Seconds to wait between Syft download retry attempts                                                                                                    | `5`                              |
 | `github-token`              | Authorized secret GitHub Personal Access Token.                                                                                                         | `github.token`                   |
 | `config `                   | Syft configuration file to use.                                                                                                                         |                                  |
 
@@ -184,9 +187,11 @@ A sub-action to [upload multiple SBOMs](publish-sbom/action.yml) to GitHub relea
 
 A sub-action to [download Syft](download-syft/action.yml).
 
-| Parameter      | Description                     | Default |
-| -------------- | ------------------------------- | ------- |
-| `syft-version` | The version of Syft to download |         |
+| Parameter                   | Description                                               | Default |
+| --------------------------- | --------------------------------------------------------- | ------- |
+| `syft-version`              | The version of Syft to download                           |         |
+| `syft-download-retry-count` | Number of times to retry transient Syft download failures | `3`     |
+| `syft-download-retry-delay` | Seconds to wait between Syft download retry attempts      | `5`     |
 
 Output parameters:
 

--- a/README.md
+++ b/README.md
@@ -170,8 +170,8 @@ and uploading them as workflow artifacts and release assets.
 | `upload-artifact-retention` | Retention policy in days for uploaded artifact to workflow.                                                                                             |                                  |
 | `upload-release-assets`     | Upload release assets                                                                                                                                   | `true`                           |
 | `syft-version`              | The version of Syft to use                                                                                                                              |                                  |
-| `syft-download-retry-count` | Number of times to retry transient Syft download failures                                                                                               | `3`                              |
-| `syft-download-retry-delay` | Seconds to wait between Syft download retry attempts                                                                                                    | `5`                              |
+| `syft-download-retry-count` | Number of times to retry transient Syft download failures (0-10)                                                                                        | `3`                              |
+| `syft-download-retry-delay` | Seconds to wait between Syft download retry attempts (0-300)                                                                                            | `5`                              |
 | `github-token`              | Authorized secret GitHub Personal Access Token.                                                                                                         | `github.token`                   |
 | `config `                   | Syft configuration file to use.                                                                                                                         |                                  |
 
@@ -187,11 +187,11 @@ A sub-action to [upload multiple SBOMs](publish-sbom/action.yml) to GitHub relea
 
 A sub-action to [download Syft](download-syft/action.yml).
 
-| Parameter                   | Description                                               | Default |
-| --------------------------- | --------------------------------------------------------- | ------- |
-| `syft-version`              | The version of Syft to download                           |         |
-| `syft-download-retry-count` | Number of times to retry transient Syft download failures | `3`     |
-| `syft-download-retry-delay` | Seconds to wait between Syft download retry attempts      | `5`     |
+| Parameter                   | Description                                                      | Default |
+| --------------------------- | ---------------------------------------------------------------- | ------- |
+| `syft-version`              | The version of Syft to download                                  |         |
+| `syft-download-retry-count` | Number of times to retry transient Syft download failures (0-10) | `3`     |
+| `syft-download-retry-delay` | Seconds to wait between Syft download retry attempts (0-300)     | `5`     |
 
 Output parameters:
 

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,16 @@ inputs:
     required: false
     description: "The version of Syft to use"
 
+  syft-download-retry-count:
+    required: false
+    description: "Number of times to retry transient Syft download failures"
+    default: "3"
+
+  syft-download-retry-delay:
+    required: false
+    description: "Seconds to wait between Syft download retry attempts"
+    default: "5"
+
   dependency-snapshot:
     required: false
     description: "Upload to GitHub dependency snapshot API"

--- a/action.yml
+++ b/action.yml
@@ -50,12 +50,12 @@ inputs:
 
   syft-download-retry-count:
     required: false
-    description: "Number of times to retry transient Syft download failures"
+    description: "Number of times to retry transient Syft download failures (0-10)"
     default: "3"
 
   syft-download-retry-delay:
     required: false
-    description: "Seconds to wait between Syft download retry attempts"
+    description: "Seconds to wait between Syft download retry attempts (0-300)"
     default: "5"
 
   dependency-snapshot:

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -96481,6 +96481,8 @@ var PRIOR_ARTIFACT_ENV_VAR = "ANCHORE_SBOM_ACTION_PRIOR_ARTIFACT";
 var tempDir = fs11.mkdtempSync(import_path4.default.join(import_os7.default.tmpdir(), "sbom-action-"));
 var githubDependencySnapshotFile = `${tempDir}/github.sbom.json`;
 var exeSuffix = process.platform == "win32" ? ".exe" : "";
+var DEFAULT_SYFT_DOWNLOAD_RETRY_COUNT = 3;
+var DEFAULT_SYFT_DOWNLOAD_RETRY_DELAY_SECONDS = 5;
 function getArtifactName() {
   const fileName = getArtifactNameInput();
   if (fileName) {
@@ -96611,11 +96613,53 @@ async function executeSyft({
 function isWindows() {
   return process.platform == "win32";
 }
+function getNonNegativeIntegerInput(name, defaultValue) {
+  const value = getInput(name);
+  if (!value) {
+    return defaultValue;
+  }
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${name} must be a non-negative integer`);
+  }
+  return parsed;
+}
+function sleep(ms) {
+  return new Promise((resolve3) => setTimeout(resolve3, ms));
+}
+async function downloadToolWithRetry(url2) {
+  const retryCount = getNonNegativeIntegerInput(
+    "syft-download-retry-count",
+    DEFAULT_SYFT_DOWNLOAD_RETRY_COUNT
+  );
+  const retryDelaySeconds = getNonNegativeIntegerInput(
+    "syft-download-retry-delay",
+    DEFAULT_SYFT_DOWNLOAD_RETRY_DELAY_SECONDS
+  );
+  const maxAttempts = retryCount + 1;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await downloadTool(url2);
+    } catch (error2) {
+      if (attempt >= maxAttempts) {
+        throw error2;
+      }
+      const message = error2 instanceof Error ? error2.message : String(error2);
+      warning(
+        `Syft download attempt ${attempt} of ${maxAttempts} failed: ${message}. Retrying in ${retryDelaySeconds} seconds.`
+      );
+      if (retryDelaySeconds > 0) {
+        await sleep(retryDelaySeconds * 1e3);
+      }
+    }
+  }
+  throw new Error("Syft download retry loop exited unexpectedly");
+}
 async function downloadSyftWindowsWorkaround(version3) {
   const versionNoV = version3.replace(/^v/, "");
   const url2 = `https://github.com/anchore/syft/releases/download/${version3}/syft_${versionNoV}_windows_amd64.zip`;
   info(`Downloading syft from ${url2}`);
-  const zipPath = await downloadTool(url2);
+  const zipPath = await downloadToolWithRetry(url2);
   const toolDir = await extractZip(zipPath);
   return import_path4.default.join(toolDir, `${SYFT_BINARY_NAME}${exeSuffix}`);
 }
@@ -96627,7 +96671,7 @@ async function downloadSyft() {
   }
   const url2 = `https://raw.githubusercontent.com/anchore/${name}/main/install.sh`;
   debug(`Installing ${name} ${version3}`);
-  const installPath = await downloadTool(url2);
+  const installPath = await downloadToolWithRetry(url2);
   const syftBinaryPath = `${installPath}_${name}`;
   await execute("sh", [installPath, "-d", "-b", syftBinaryPath, version3]);
   return import_path4.default.join(syftBinaryPath, name) + exeSuffix;

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -96483,6 +96483,8 @@ var githubDependencySnapshotFile = `${tempDir}/github.sbom.json`;
 var exeSuffix = process.platform == "win32" ? ".exe" : "";
 var DEFAULT_SYFT_DOWNLOAD_RETRY_COUNT = 3;
 var DEFAULT_SYFT_DOWNLOAD_RETRY_DELAY_SECONDS = 5;
+var MAX_SYFT_DOWNLOAD_RETRY_COUNT = 10;
+var MAX_SYFT_DOWNLOAD_RETRY_DELAY_SECONDS = 300;
 function getArtifactName() {
   const fileName = getArtifactNameInput();
   if (fileName) {
@@ -96613,35 +96615,43 @@ async function executeSyft({
 function isWindows() {
   return process.platform == "win32";
 }
-function getNonNegativeIntegerInput(name, defaultValue) {
+function getBoundedNonNegativeIntegerInput(name, defaultValue, maximumValue) {
   const value = getInput(name);
   if (!value) {
     return defaultValue;
   }
   const parsed = Number(value);
-  if (!Number.isInteger(parsed) || parsed < 0) {
-    throw new Error(`${name} must be a non-negative integer`);
+  if (!Number.isInteger(parsed) || parsed < 0 || parsed > maximumValue) {
+    throw new Error(`${name} must be an integer between 0 and ${maximumValue}`);
   }
   return parsed;
 }
 function sleep(ms) {
   return new Promise((resolve3) => setTimeout(resolve3, ms));
 }
+function isTransientDownloadError(error2) {
+  const message = error2 instanceof Error ? error2.message : String(error2);
+  return /\b(?:408|425|429|5\d{2})\b/.test(message) || /\b(?:EAI_AGAIN|ECONNREFUSED|ECONNRESET|EHOSTUNREACH|ENETUNREACH|ETIMEDOUT)\b/i.test(
+    message
+  ) || /socket hang up|network.*timeout|timed out/i.test(message);
+}
 async function downloadToolWithRetry(url2) {
-  const retryCount = getNonNegativeIntegerInput(
+  const retryCount = getBoundedNonNegativeIntegerInput(
     "syft-download-retry-count",
-    DEFAULT_SYFT_DOWNLOAD_RETRY_COUNT
+    DEFAULT_SYFT_DOWNLOAD_RETRY_COUNT,
+    MAX_SYFT_DOWNLOAD_RETRY_COUNT
   );
-  const retryDelaySeconds = getNonNegativeIntegerInput(
+  const retryDelaySeconds = getBoundedNonNegativeIntegerInput(
     "syft-download-retry-delay",
-    DEFAULT_SYFT_DOWNLOAD_RETRY_DELAY_SECONDS
+    DEFAULT_SYFT_DOWNLOAD_RETRY_DELAY_SECONDS,
+    MAX_SYFT_DOWNLOAD_RETRY_DELAY_SECONDS
   );
   const maxAttempts = retryCount + 1;
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
       return await downloadTool(url2);
     } catch (error2) {
-      if (attempt >= maxAttempts) {
+      if (attempt >= maxAttempts || !isTransientDownloadError(error2)) {
         throw error2;
       }
       const message = error2 instanceof Error ? error2.message : String(error2);

--- a/download-syft/action.yml
+++ b/download-syft/action.yml
@@ -16,12 +16,12 @@ inputs:
 
   syft-download-retry-count:
     required: false
-    description: "Number of times to retry transient Syft download failures"
+    description: "Number of times to retry transient Syft download failures (0-10)"
     default: "3"
 
   syft-download-retry-delay:
     required: false
-    description: "Seconds to wait between Syft download retry attempts"
+    description: "Seconds to wait between Syft download retry attempts (0-300)"
     default: "5"
 
 outputs:

--- a/download-syft/action.yml
+++ b/download-syft/action.yml
@@ -14,6 +14,16 @@ inputs:
     required: false
     description: "The version of Syft to download"
 
+  syft-download-retry-count:
+    required: false
+    description: "Number of times to retry transient Syft download failures"
+    default: "3"
+
+  syft-download-retry-delay:
+    required: false
+    description: "Seconds to wait between Syft download retry attempts"
+    default: "5"
+
 outputs:
   cmd:
     description: "A reference to the Syft command"

--- a/src/github/SyftGithubAction.ts
+++ b/src/github/SyftGithubAction.ts
@@ -31,6 +31,8 @@ const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "sbom-action-"));
 const githubDependencySnapshotFile = `${tempDir}/github.sbom.json`;
 
 const exeSuffix = process.platform == "win32" ? ".exe" : "";
+const DEFAULT_SYFT_DOWNLOAD_RETRY_COUNT = 3;
+const DEFAULT_SYFT_DOWNLOAD_RETRY_DELAY_SECONDS = 5;
 
 /**
  * Tries to get a unique artifact name or otherwise as appropriate as possible
@@ -208,11 +210,64 @@ function isWindows(): boolean {
   return process.platform == "win32";
 }
 
+function getNonNegativeIntegerInput(
+  name: string,
+  defaultValue: number,
+): number {
+  const value = core.getInput(name);
+  if (!value) {
+    return defaultValue;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${name} must be a non-negative integer`);
+  }
+
+  return parsed;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function downloadToolWithRetry(url: string): Promise<string> {
+  const retryCount = getNonNegativeIntegerInput(
+    "syft-download-retry-count",
+    DEFAULT_SYFT_DOWNLOAD_RETRY_COUNT,
+  );
+  const retryDelaySeconds = getNonNegativeIntegerInput(
+    "syft-download-retry-delay",
+    DEFAULT_SYFT_DOWNLOAD_RETRY_DELAY_SECONDS,
+  );
+  const maxAttempts = retryCount + 1;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await cache.downloadTool(url);
+    } catch (error) {
+      if (attempt >= maxAttempts) {
+        throw error;
+      }
+
+      const message = error instanceof Error ? error.message : String(error);
+      core.warning(
+        `Syft download attempt ${attempt} of ${maxAttempts} failed: ${message}. Retrying in ${retryDelaySeconds} seconds.`,
+      );
+      if (retryDelaySeconds > 0) {
+        await sleep(retryDelaySeconds * 1000);
+      }
+    }
+  }
+
+  throw new Error("Syft download retry loop exited unexpectedly");
+}
+
 async function downloadSyftWindowsWorkaround(version: string): Promise<string> {
   const versionNoV = version.replace(/^v/, "");
   const url = `https://github.com/anchore/syft/releases/download/${version}/syft_${versionNoV}_windows_amd64.zip`;
   core.info(`Downloading syft from ${url}`);
-  const zipPath = await cache.downloadTool(url);
+  const zipPath = await downloadToolWithRetry(url);
   const toolDir = await cache.extractZip(zipPath);
   return path.join(toolDir, `${SYFT_BINARY_NAME}${exeSuffix}`);
 }
@@ -232,7 +287,7 @@ export async function downloadSyft(): Promise<string> {
   core.debug(`Installing ${name} ${version}`);
 
   // Download the installer, and run
-  const installPath = await cache.downloadTool(url);
+  const installPath = await downloadToolWithRetry(url);
 
   const syftBinaryPath = `${installPath}_${name}`;
 

--- a/src/github/SyftGithubAction.ts
+++ b/src/github/SyftGithubAction.ts
@@ -33,6 +33,8 @@ const githubDependencySnapshotFile = `${tempDir}/github.sbom.json`;
 const exeSuffix = process.platform == "win32" ? ".exe" : "";
 const DEFAULT_SYFT_DOWNLOAD_RETRY_COUNT = 3;
 const DEFAULT_SYFT_DOWNLOAD_RETRY_DELAY_SECONDS = 5;
+const MAX_SYFT_DOWNLOAD_RETRY_COUNT = 10;
+const MAX_SYFT_DOWNLOAD_RETRY_DELAY_SECONDS = 300;
 
 /**
  * Tries to get a unique artifact name or otherwise as appropriate as possible
@@ -210,9 +212,10 @@ function isWindows(): boolean {
   return process.platform == "win32";
 }
 
-function getNonNegativeIntegerInput(
+function getBoundedNonNegativeIntegerInput(
   name: string,
   defaultValue: number,
+  maximumValue: number,
 ): number {
   const value = core.getInput(name);
   if (!value) {
@@ -220,8 +223,8 @@ function getNonNegativeIntegerInput(
   }
 
   const parsed = Number(value);
-  if (!Number.isInteger(parsed) || parsed < 0) {
-    throw new Error(`${name} must be a non-negative integer`);
+  if (!Number.isInteger(parsed) || parsed < 0 || parsed > maximumValue) {
+    throw new Error(`${name} must be an integer between 0 and ${maximumValue}`);
   }
 
   return parsed;
@@ -231,14 +234,27 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function isTransientDownloadError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    /\b(?:408|425|429|5\d{2})\b/.test(message) ||
+    /\b(?:EAI_AGAIN|ECONNREFUSED|ECONNRESET|EHOSTUNREACH|ENETUNREACH|ETIMEDOUT)\b/i.test(
+      message,
+    ) ||
+    /socket hang up|network.*timeout|timed out/i.test(message)
+  );
+}
+
 async function downloadToolWithRetry(url: string): Promise<string> {
-  const retryCount = getNonNegativeIntegerInput(
+  const retryCount = getBoundedNonNegativeIntegerInput(
     "syft-download-retry-count",
     DEFAULT_SYFT_DOWNLOAD_RETRY_COUNT,
+    MAX_SYFT_DOWNLOAD_RETRY_COUNT,
   );
-  const retryDelaySeconds = getNonNegativeIntegerInput(
+  const retryDelaySeconds = getBoundedNonNegativeIntegerInput(
     "syft-download-retry-delay",
     DEFAULT_SYFT_DOWNLOAD_RETRY_DELAY_SECONDS,
+    MAX_SYFT_DOWNLOAD_RETRY_DELAY_SECONDS,
   );
   const maxAttempts = retryCount + 1;
 
@@ -246,7 +262,7 @@ async function downloadToolWithRetry(url: string): Promise<string> {
     try {
       return await cache.downloadTool(url);
     } catch (error) {
-      if (attempt >= maxAttempts) {
+      if (attempt >= maxAttempts || !isTransientDownloadError(error)) {
         throw error;
       }
 

--- a/tests/SyftGithubAction.test.ts
+++ b/tests/SyftGithubAction.test.ts
@@ -20,6 +20,10 @@ const action = await import("../src/github/SyftGithubAction");
 const { downloadSyft, runAndFailBuildOnException } = action;
 const { mapToWSLPath } = await import("../src/github/Executor");
 
+function assertSyftCommand(command: string) {
+  assert.ok(command.endsWith("syft") || command.endsWith("syft.exe"));
+}
+
 describe("Action", { timeout: 30000 }, () => {
   beforeEach(() => {
     restoreInitialData();
@@ -27,7 +31,31 @@ describe("Action", { timeout: 30000 }, () => {
 
   it("downloads syft", async () => {
     const path = await downloadSyft();
-    assert.equal(path, "download-tool_syft/syft");
+    assertSyftCommand(path);
+  });
+
+  it("retries transient syft download failures", async () => {
+    setData({
+      downloadToolFailures: ["received HTTP status=504"],
+      inputs: {
+        "syft-download-retry-delay": "0",
+      },
+    });
+
+    const path = await downloadSyft();
+
+    assertSyftCommand(path);
+    assert.equal(data.downloadToolFailures.length, 0);
+  });
+
+  it("rejects invalid syft download retry input", async () => {
+    setData({
+      inputs: {
+        "syft-download-retry-count": "-1",
+      },
+    });
+
+    await assert.rejects(downloadSyft, /syft-download-retry-count/);
   });
 
   it("runs with default inputs on push", async () => {
@@ -322,7 +350,7 @@ describe("Action", { timeout: 30000 }, () => {
 
     const { cmd, args, env } = data.execArgs;
 
-    assert.ok(cmd.endsWith("syft"));
+    assertSyftCommand(cmd);
     assert.ok(args.includes("somewhere/org/img"));
     assert.ok(!env.SYFT_REGISTRY_AUTH_USERNAME);
     assert.ok(!env.SYFT_REGISTRY_AUTH_PASSWORD);
@@ -341,7 +369,7 @@ describe("Action", { timeout: 30000 }, () => {
 
     const { cmd, args, env } = data.execArgs;
 
-    assert.ok(cmd.endsWith("syft"));
+    assertSyftCommand(cmd);
     assert.ok(args.includes("registry:somewhere/org/img"));
     assert.equal(env.SYFT_REGISTRY_AUTH_USERNAME, "mr_awesome");
     assert.equal(env.SYFT_REGISTRY_AUTH_PASSWORD, "super_secret");

--- a/tests/SyftGithubAction.test.ts
+++ b/tests/SyftGithubAction.test.ts
@@ -48,6 +48,23 @@ describe("Action", { timeout: 30000 }, () => {
     assert.equal(data.downloadToolFailures.length, 0);
   });
 
+  it("does not retry permanent syft download failures", async () => {
+    setData({
+      downloadToolFailures: [
+        "received HTTP status=404",
+        "this failure must not be consumed",
+      ],
+      inputs: {
+        "syft-download-retry-delay": "0",
+      },
+    });
+
+    await assert.rejects(downloadSyft, /HTTP status=404/);
+    assert.deepEqual(data.downloadToolFailures, [
+      "this failure must not be consumed",
+    ]);
+  });
+
   it("rejects invalid syft download retry input", async () => {
     setData({
       inputs: {
@@ -56,6 +73,25 @@ describe("Action", { timeout: 30000 }, () => {
     });
 
     await assert.rejects(downloadSyft, /syft-download-retry-count/);
+  });
+
+  it("rejects excessive syft download retry settings", async () => {
+    setData({
+      inputs: {
+        "syft-download-retry-count": "11",
+      },
+    });
+
+    await assert.rejects(downloadSyft, /between 0 and 10/);
+
+    setData({
+      inputs: {
+        "syft-download-retry-count": "3",
+        "syft-download-retry-delay": "301",
+      },
+    });
+
+    await assert.rejects(downloadSyft, /between 0 and 300/);
   });
 
   it("runs with default inputs on push", async () => {

--- a/tests/mocks.ts
+++ b/tests/mocks.ts
@@ -64,6 +64,8 @@ export function getMocks(test: testType) {
       enabled: false,
       log: [],
     }
+
+    downloadToolFailures: string[] = [];
   }
 
   const data = Object.freeze(new Data());
@@ -185,6 +187,10 @@ export function getMocks(test: testType) {
 
       "@actions/tool-cache": () => ({
         downloadTool() {
+          const failure = data.downloadToolFailures.shift();
+          if (failure) {
+            throw new Error(failure);
+          }
           return "download-tool";
         },
         extractZip() {


### PR DESCRIPTION
## Summary

- Add retry handling around Syft downloads used by the main action and `download-syft` sub-action.
- Add configurable `syft-download-retry-count` and `syft-download-retry-delay` inputs with conservative defaults.
- Cover transient download recovery and invalid retry input in tests.
- Make Syft command assertions portable across Linux and Windows paths.

Closes #667.

## Verification

- `npm run build`
- `npm run lint`
- `node --import tsx --test --experimental-test-module-mocks tests/SyftGithubAction.test.ts`
- `npm run package`

Note: a full `npm test` run on Windows passed the core action tests but the integration snapshot tests failed while expanding a mocked artifact path as a zip via PowerShell `Expand-Archive`. The focused Syft action tests covering this change pass locally.